### PR TITLE
Added pytest-cov to req-dev.txt to fix pytest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black ~= 22.0
 pytest
+pytest-cov
 setuptools_scm
 --editable .


### PR DESCRIPTION
pytest-cov is required when running tests due to the use of --cov arguments in the pytest.ini file