### PR TITLE
Add SETOSystemCosting to aggregate system treatment and energy costs

### DIFF
--- a/src/watertap_contrib/seto/costing/__init__.py
+++ b/src/watertap_contrib/seto/costing/__init__.py
@@ -1,2 +1,2 @@
 from .seto_zero_order_costing import SETOZeroOrderCosting
-from .seto_watertap_costing_package import SETOWaterTAPCosting
+from .seto_watertap_costing_package import SETOWaterTAPCosting, SETOSystemCosting

--- a/src/watertap_contrib/seto/costing/__init__.py
+++ b/src/watertap_contrib/seto/costing/__init__.py
@@ -1,2 +1,7 @@
 from .seto_zero_order_costing import SETOZeroOrderCosting
-from .seto_watertap_costing_package import SETOWaterTAPCosting, SETOSystemCosting
+from .seto_watertap_costing_package import (
+    SETOWaterTAPCosting,
+    SETOSystemCosting,
+    TreatmentCosting,
+    EnergyCosting,
+)

--- a/src/watertap_contrib/seto/costing/seto_watertap_costing_package.py
+++ b/src/watertap_contrib/seto/costing/seto_watertap_costing_package.py
@@ -3,7 +3,7 @@ import pyomo.environ as pyo
 from idaes.core import declare_process_block_class
 from idaes.models.unit_models import Mixer
 
-from watertap.costing.watertap_costing_package import WaterTAPCostingData
+from watertap.costing.watertap_costing_package import WaterTAPCostingData, _DefinedFlowsDict
 from watertap.unit_models import (
     ReverseOsmosis0D,
     ReverseOsmosis1D,
@@ -19,7 +19,10 @@ from watertap.unit_models import (
     IonExchange0D,
     GAC,
 )
-
+from idaes.core.base.costing_base import (
+    FlowsheetCostingBlockData,
+    register_idaes_currency_units,
+)
 from watertap.costing.units.crystallizer import cost_crystallizer
 from watertap.costing.units.electrodialysis import cost_electrodialysis
 from watertap.costing.units.energy_recovery_device import cost_energy_recovery_device
@@ -36,7 +39,7 @@ from watertap_contrib.seto.solar_models.zero_order import SolarEnergyZO, Photovo
 from watertap_contrib.seto.costing.solar.photovoltaic import cost_pv
 from watertap_contrib.seto.unit_models.surrogate import LTMEDSurrogate
 from watertap_contrib.seto.costing.units.lt_med_surrogate import cost_lt_med_surrogate
-
+from watertap_contrib.seto.core import PySAMWaterTAP
 
 @declare_process_block_class("SETOWaterTAPCosting")
 class SETOWaterTAPCostingData(WaterTAPCostingData):
@@ -120,3 +123,295 @@ class SETOWaterTAPCostingData(WaterTAPCostingData):
             + self.aggregate_variable_operating_cost
             + sum(self.aggregate_flow_costs.values()) * self.utilization_factor
         )
+
+
+@declare_process_block_class("SETOSystemCosting")
+class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
+
+    def build(self):
+        super().build()
+
+        self._registered_LCOWs = {}
+
+    def build_global_params(self):
+        # Register currency and conversion rates based on CE Index
+        register_idaes_currency_units()
+        if "USD_2021" not in pyo.units._pint_registry:
+            pyo.units.load_definitions_from_strings(["USD_2021 = 500/708.0 * USD_CE500"])
+
+        self.base_currency = pyo.units.USD_2021
+
+        # Set a base period for all operating costs
+        self.base_period = pyo.units.year
+
+        # Define standard material flows and costs
+        # The WaterTAP costing package creates flows
+        # in a lazy fashion, the first time `cost_flow`
+        # is called for a flow. The `_DefinedFlowsDict`
+        # prevents defining more than one flow with
+        # the same name.
+        self.defined_flows = _DefinedFlowsDict()
+
+        # Build flowsheet level costing components
+        # These are the global parameters
+        self.utilization_factor = pyo.Var(
+            initialize=1,
+            doc="Plant capacity utilization [fraction of uptime]",
+            units=pyo.units.dimensionless,
+        )
+
+        self.plant_lifetime = pyo.Var(
+            initialize=20, units=self.base_period, doc="Plant lifetime"
+        )
+
+        self.factor_total_investment = pyo.Var(
+            initialize=1,
+            doc="Total investment factor [investment cost/equipment cost]",
+            units=pyo.units.dimensionless,
+        )
+        self.factor_maintenance_labor_chemical = pyo.Var(
+            initialize=0.03,
+            doc="Maintenance-labor-chemical factor [fraction of investment cost/year]",
+            units=pyo.units.year**-1,
+        )
+
+        self.wacc = pyo.Param(initialize=0.05, mutable=True, units=pyo.units.dimensionless, doc="Weighted Average Cost of Capital [WACC]")
+
+        self.electricity_cost = pyo.Param(
+            mutable=True,
+            initialize=0.0718, # From EIA for 2021
+            doc="Electricity cost",
+            units=self.base_currency / pyo.units.kWh,
+        )
+
+        self.add_defined_flow("electricity", self.electricity_cost)
+
+        self.electrical_carbon_intensity = pyo.Param(
+            mutable=True,
+            initialize=0.475,
+            doc="Grid carbon intensity [kgCO2_eq/kWh]",
+            units=pyo.units.kg / pyo.units.kWh,
+        )
+
+        
+        self.factor_capital_annualization = pyo.Expression(
+            expr=(
+                (
+                    self.wacc
+                    * (1 + self.wacc) ** (self.plant_lifetime / self.base_period)
+                )
+                / (((1 + self.wacc) ** (self.plant_lifetime / self.base_period)) - 1)
+                / self.base_period
+            )
+        )
+        # fix the parameters
+        self.fix_all_vars()
+        self.build_integrated_costs()
+    
+    def build_process_costs(self):
+        pass 
+
+    def build_integrated_costs(self):
+    # def build_process_costs(self):
+        treat_cost = self._get_treatment_cost_block()
+        en_cost = self._get_energy_cost_block()
+
+        self.total_capital_cost = pyo.Var(
+            initialize=1e3,
+            # domain=pyo.NonNegativeReals,
+            doc="Total capital cost for integrated system",
+            units=self.base_currency,
+        )
+        self.total_operating_cost = pyo.Var(
+            initialize=1e3,
+            # domain=pyo.NonNegativeReals,
+            doc="Total operating cost for integrated system",
+            units=self.base_currency / self.base_period,
+        )
+        self.aggregate_flow_electricity = pyo.Var(
+            initialize=1e3,
+            # domain=pyo.NonNegativeReals,
+            doc="Aggregated electricity flow",
+            units=pyo.units.kW
+        )
+
+        # if all("heat" in b.defined_flows for b in [treat_cost, en_cost]):
+        #     self.aggregate_flow_heat = pyo.Var(
+        #         initialize=1e3,
+        #         # domain=pyo.NonNegativeReals,
+        #         doc="Aggregated heat flow",
+        #         units=pyo.units.kW
+        #     )
+
+        self.total_capital_cost_constraint = pyo.Constraint(expr=self.total_capital_cost == pyo.units.convert(treat_cost.total_capital_cost + en_cost.total_capital_cost, to_units=self.base_currency))
+
+        self.total_operating_cost_constraint = pyo.Constraint(expr=self.total_operating_cost == pyo.units.convert(treat_cost.total_operating_cost + en_cost.total_operating_cost, to_units=self.base_currency / self.base_period))
+
+        self.aggregate_flow_electricity_constraint = pyo.Constraint(expr=self.aggregate_flow_electricity == treat_cost.aggregate_flow_electricity + en_cost.aggregate_flow_electricity)
+
+        # if all("heat" in b.defined_flows for b in [treat_cost, en_cost]):
+        #     self.aggregate_flow_heat_constraint = pyo.Constraint(expr=self.aggregate_flow_heat == treat_cost.aggregate_flow_heat + en_cost.aggregate_flow_heat)
+
+
+    def add_LCOW(self, flow_rate, name="LCOW"):
+        """
+        Add Levelized Cost of Water (LCOW) to costing block.
+        Args:
+            flow_rate - flow rate of water (volumetric) to be used in
+                        calculating LCOW
+            name (optional) - name for the LCOW variable (default: LCOW)
+        """
+
+        LCOW = pyo.Var(
+            doc=f"Levelized Cost of Water based on flow {flow_rate.name}",
+            units=self.base_currency / pyo.units.m**3,
+        )
+        self.add_component(name, LCOW)
+
+        LCOW_constraint = pyo.Constraint(
+            expr=LCOW
+            == (
+                self.total_capital_cost * self.factor_capital_annualization
+                + self.total_operating_cost
+            )
+            / (
+                pyo.units.convert(
+                    flow_rate, to_units=pyo.units.m**3 / self.base_period
+                )
+                * self.utilization_factor
+            ),
+            doc=f"Constraint for Levelized Cost of Water based on flow {flow_rate.name}",
+        )
+        self.add_component(name + "_constraint", LCOW_constraint)
+
+        self._registered_LCOWs[name] = (LCOW, LCOW_constraint)
+
+    def add_LCOE(self, e_model="pysam"):
+        """
+        Add Levelized Cost of Energy (LCOE) to costing block.
+        Args:
+            e_model - energy modeling approach used (PySAM or surrogate)
+        """
+
+        if e_model == "pysam":
+            pysam = self._get_pysam()
+
+            if not pysam._has_been_run:
+                raise Exception(f"PySAM model {pysam._pysam_model_name} has not yet been run, so there is no annual_energy data available."
+                                "You must run the PySAM model before adding LCOE metric.")
+
+            en_cost = self._get_energy_cost_block()
+
+            self.annual_energy_generated = pyo.Param(initialize=pysam.annual_energy, units=pyo.units.kWh / pyo.units.year, doc=f"Annual energy generated by {pysam._pysam_model_name}")
+            LCOE_expr = pyo.Expression(expr=(en_cost.total_capital_cost *self.factor_capital_annualization + en_cost.total_operating_cost) / self.annual_energy_generated * self.utilization_factor)
+            self.add_component("LCOE", LCOE_expr)
+        
+        if e_model == "surrogate":
+            raise NotImplementedError("We don't have surrogate models yet!")
+
+        
+
+
+
+    
+    def add_specific_electric_energy_consumption(
+        self, flow_rate
+    ):
+        """
+        Add specific electric energy consumption (kWh/m**3) to costing block.
+        Args:
+            flow_rate - flow rate of water (volumetric) to be used in
+                        calculating specific energy consumption
+        """
+
+        specific_electric_energy_consumption = pyo.Var(initialize=100, doc=f"Specific electric energy consumption based on flow {flow_rate.name}")
+
+        self.add_component("specific_electric_energy_consumption", specific_electric_energy_consumption)
+
+        specific_electric_energy_consumption_constraint = pyo.Constraint(expr=specific_electric_energy_consumption==self.aggregate_flow_electricity
+                / pyo.units.convert(
+                    flow_rate, to_units=pyo.units.m**3 / pyo.units.hr
+                ))
+
+        self.add_component("specific_electric_energy_consumption_constraint", specific_electric_energy_consumption_constraint)
+
+    def add_specific_thermal_energy_consumption(
+        self, flow_rate
+    ):
+        """
+        Add specific thermal energy consumption (kWh/m**3) to costing block.
+        Args:
+            flow_rate - flow rate of water (volumetric) to be used in
+                        calculating specific energy consumption
+        """
+
+        specific_thermal_energy_consumption = pyo.Var(initialize=100, doc=f"Specific thermal energy consumption based on flow {flow_rate.name}")
+
+        self.add_component("specific_thermal_energy_consumption", specific_thermal_energy_consumption)
+
+        specific_thermal_energy_consumption_constraint = pyo.Constraint(expr=specific_thermal_energy_consumption==self.aggregate_flow_heat
+                / pyo.units.convert(
+                    flow_rate, to_units=pyo.units.m**3 / pyo.units.hr
+                ))
+
+        self.add_component("specific_thermal_energy_consumption_constraint", specific_thermal_energy_consumption_constraint)
+
+    def add_defined_flow(self, flow_name, flow_cost):
+        """
+        This method adds a defined flow to the costing block.
+
+        NOTE: Use this method to add `defined_flows` to the costing block
+              to ensure updates to `flow_cost` get propagated in the model.
+              See https://github.com/IDAES/idaes-pse/pull/1014 for details.
+
+        Args:
+            flow_name: string containing the name of the flow to register
+            flow_cost: Pyomo expression that represents the flow unit cost
+
+        Returns:
+            None
+        """
+        flow_cost_name = flow_name + "_cost"
+        current_flow_cost = self.component(flow_cost_name)
+        if current_flow_cost is None:
+            self.add_component(flow_cost_name, pyo.Expression(expr=flow_cost))
+            self.defined_flows._setitem(flow_name, self.component(flow_cost_name))
+        elif current_flow_cost is flow_cost:
+            self.defined_flows._setitem(flow_name, current_flow_cost)
+        else:
+            # if we get here then there's an attribute named
+            # flow_cost_name on the block, which is an error
+            raise RuntimeError(
+                f"Attribute {flow_cost_name} already exists "
+                f"on the costing block, but is not {flow_cost}"
+            )
+
+    def _get_treatment_cost_block(self):
+        try:
+            treat_cost = self.parent_block().treatment.costing
+        except:
+            raise Exception("SETO integrated models require separate treatment and energy costing blocks.")
+        return treat_cost
+
+    def _get_energy_cost_block(self):
+        try:
+            en_cost = self.parent_block().energy.costing
+        except:
+            raise Exception("SETO integrated models require separate treatment and energy costing blocks.")
+        return en_cost
+
+    def _get_pysam(self):
+        pysam_block_test_lst = []
+        for k, v in vars(self.model()).items():
+            if isinstance(v, PySAMWaterTAP):
+                pysam_block_test_lst.append(k)
+        
+        if len(pysam_block_test_lst) != 1:
+            raise Exception("There is no instance of PySAMWaterTAP on this model.")
+        
+        else:
+            pysam = getattr(self.model(), pysam_block_test_lst[0])
+            return pysam
+        
+        
+

--- a/src/watertap_contrib/seto/costing/seto_watertap_costing_package.py
+++ b/src/watertap_contrib/seto/costing/seto_watertap_costing_package.py
@@ -63,7 +63,10 @@ class SETOWaterTAPCostingData(WaterTAPCostingData):
     def build_global_params(self):
         super().build_global_params()
 
-        self.base_currency = pyo.units.USD_2020
+        if "USD_2021" not in pyo.units._pint_registry:
+            pyo.units.load_definitions_from_strings(["USD_2021 = 500/708.0 * USD_CE500"])
+
+        self.base_currency = pyo.units.USD_2021
         self.plant_lifetime = pyo.Var(
             initialize=20, units=self.base_period, doc="Plant lifetime"
         )

--- a/src/watertap_contrib/seto/costing/seto_watertap_costing_package.py
+++ b/src/watertap_contrib/seto/costing/seto_watertap_costing_package.py
@@ -3,7 +3,10 @@ import pyomo.environ as pyo
 from idaes.core import declare_process_block_class
 from idaes.models.unit_models import Mixer
 
-from watertap.costing.watertap_costing_package import WaterTAPCostingData, _DefinedFlowsDict
+from watertap.costing.watertap_costing_package import (
+    WaterTAPCostingData,
+    _DefinedFlowsDict,
+)
 from watertap.unit_models import (
     ReverseOsmosis0D,
     ReverseOsmosis1D,
@@ -41,6 +44,7 @@ from watertap_contrib.seto.unit_models.surrogate import LTMEDSurrogate
 from watertap_contrib.seto.costing.units.lt_med_surrogate import cost_lt_med_surrogate
 from watertap_contrib.seto.core import PySAMWaterTAP
 
+
 @declare_process_block_class("SETOWaterTAPCosting")
 class SETOWaterTAPCostingData(WaterTAPCostingData):
     unit_mapping = {
@@ -67,7 +71,9 @@ class SETOWaterTAPCostingData(WaterTAPCostingData):
         super().build_global_params()
 
         if "USD_2021" not in pyo.units._pint_registry:
-            pyo.units.load_definitions_from_strings(["USD_2021 = 500/708.0 * USD_CE500"])
+            pyo.units.load_definitions_from_strings(
+                ["USD_2021 = 500/708.0 * USD_CE500"]
+            )
 
         self.base_currency = pyo.units.USD_2021
         self.plant_lifetime = pyo.Var(
@@ -127,7 +133,6 @@ class SETOWaterTAPCostingData(WaterTAPCostingData):
 
 @declare_process_block_class("SETOSystemCosting")
 class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
-
     def build(self):
         super().build()
 
@@ -137,7 +142,9 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
         # Register currency and conversion rates based on CE Index
         register_idaes_currency_units()
         if "USD_2021" not in pyo.units._pint_registry:
-            pyo.units.load_definitions_from_strings(["USD_2021 = 500/708.0 * USD_CE500"])
+            pyo.units.load_definitions_from_strings(
+                ["USD_2021 = 500/708.0 * USD_CE500"]
+            )
 
         self.base_currency = pyo.units.USD_2021
 
@@ -175,11 +182,16 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
             units=pyo.units.year**-1,
         )
 
-        self.wacc = pyo.Param(initialize=0.05, mutable=True, units=pyo.units.dimensionless, doc="Weighted Average Cost of Capital [WACC]")
+        self.wacc = pyo.Param(
+            initialize=0.05,
+            mutable=True,
+            units=pyo.units.dimensionless,
+            doc="Weighted Average Cost of Capital [WACC]",
+        )
 
         self.electricity_cost = pyo.Param(
             mutable=True,
-            initialize=0.0718, # From EIA for 2021
+            initialize=0.0718,  # From EIA for 2021
             doc="Electricity cost",
             units=self.base_currency / pyo.units.kWh,
         )
@@ -193,7 +205,6 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
             units=pyo.units.kg / pyo.units.kWh,
         )
 
-        
         self.factor_capital_annualization = pyo.Expression(
             expr=(
                 (
@@ -207,12 +218,12 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
         # fix the parameters
         self.fix_all_vars()
         self.build_integrated_costs()
-    
+
     def build_process_costs(self):
-        pass 
+        pass
 
     def build_integrated_costs(self):
-    # def build_process_costs(self):
+        # def build_process_costs(self):
         treat_cost = self._get_treatment_cost_block()
         en_cost = self._get_energy_cost_block()
 
@@ -232,7 +243,7 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
             initialize=1e3,
             # domain=pyo.NonNegativeReals,
             doc="Aggregated electricity flow",
-            units=pyo.units.kW
+            units=pyo.units.kW,
         )
 
         # if all("heat" in b.defined_flows for b in [treat_cost, en_cost]):
@@ -243,15 +254,30 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
         #         units=pyo.units.kW
         #     )
 
-        self.total_capital_cost_constraint = pyo.Constraint(expr=self.total_capital_cost == pyo.units.convert(treat_cost.total_capital_cost + en_cost.total_capital_cost, to_units=self.base_currency))
+        self.total_capital_cost_constraint = pyo.Constraint(
+            expr=self.total_capital_cost
+            == pyo.units.convert(
+                treat_cost.total_capital_cost + en_cost.total_capital_cost,
+                to_units=self.base_currency,
+            )
+        )
 
-        self.total_operating_cost_constraint = pyo.Constraint(expr=self.total_operating_cost == pyo.units.convert(treat_cost.total_operating_cost + en_cost.total_operating_cost, to_units=self.base_currency / self.base_period))
+        self.total_operating_cost_constraint = pyo.Constraint(
+            expr=self.total_operating_cost
+            == pyo.units.convert(
+                treat_cost.total_operating_cost + en_cost.total_operating_cost,
+                to_units=self.base_currency / self.base_period,
+            )
+        )
 
-        self.aggregate_flow_electricity_constraint = pyo.Constraint(expr=self.aggregate_flow_electricity == treat_cost.aggregate_flow_electricity + en_cost.aggregate_flow_electricity)
+        self.aggregate_flow_electricity_constraint = pyo.Constraint(
+            expr=self.aggregate_flow_electricity
+            == treat_cost.aggregate_flow_electricity
+            + en_cost.aggregate_flow_electricity
+        )
 
         # if all("heat" in b.defined_flows for b in [treat_cost, en_cost]):
         #     self.aggregate_flow_heat_constraint = pyo.Constraint(expr=self.aggregate_flow_heat == treat_cost.aggregate_flow_heat + en_cost.aggregate_flow_heat)
-
 
     def add_LCOW(self, flow_rate, name="LCOW"):
         """
@@ -297,26 +323,32 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
             pysam = self._get_pysam()
 
             if not pysam._has_been_run:
-                raise Exception(f"PySAM model {pysam._pysam_model_name} has not yet been run, so there is no annual_energy data available."
-                                "You must run the PySAM model before adding LCOE metric.")
+                raise Exception(
+                    f"PySAM model {pysam._pysam_model_name} has not yet been run, so there is no annual_energy data available."
+                    "You must run the PySAM model before adding LCOE metric."
+                )
 
             en_cost = self._get_energy_cost_block()
 
-            self.annual_energy_generated = pyo.Param(initialize=pysam.annual_energy, units=pyo.units.kWh / pyo.units.year, doc=f"Annual energy generated by {pysam._pysam_model_name}")
-            LCOE_expr = pyo.Expression(expr=(en_cost.total_capital_cost *self.factor_capital_annualization + en_cost.total_operating_cost) / self.annual_energy_generated * self.utilization_factor)
+            self.annual_energy_generated = pyo.Param(
+                initialize=pysam.annual_energy,
+                units=pyo.units.kWh / pyo.units.year,
+                doc=f"Annual energy generated by {pysam._pysam_model_name}",
+            )
+            LCOE_expr = pyo.Expression(
+                expr=(
+                    en_cost.total_capital_cost * self.factor_capital_annualization
+                    + en_cost.total_operating_cost
+                )
+                / self.annual_energy_generated
+                * self.utilization_factor
+            )
             self.add_component("LCOE", LCOE_expr)
-        
+
         if e_model == "surrogate":
             raise NotImplementedError("We don't have surrogate models yet!")
 
-        
-
-
-
-    
-    def add_specific_electric_energy_consumption(
-        self, flow_rate
-    ):
+    def add_specific_electric_energy_consumption(self, flow_rate):
         """
         Add specific electric energy consumption (kWh/m**3) to costing block.
         Args:
@@ -324,20 +356,27 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
                         calculating specific energy consumption
         """
 
-        specific_electric_energy_consumption = pyo.Var(initialize=100, doc=f"Specific electric energy consumption based on flow {flow_rate.name}")
+        specific_electric_energy_consumption = pyo.Var(
+            initialize=100,
+            doc=f"Specific electric energy consumption based on flow {flow_rate.name}",
+        )
 
-        self.add_component("specific_electric_energy_consumption", specific_electric_energy_consumption)
+        self.add_component(
+            "specific_electric_energy_consumption", specific_electric_energy_consumption
+        )
 
-        specific_electric_energy_consumption_constraint = pyo.Constraint(expr=specific_electric_energy_consumption==self.aggregate_flow_electricity
-                / pyo.units.convert(
-                    flow_rate, to_units=pyo.units.m**3 / pyo.units.hr
-                ))
+        specific_electric_energy_consumption_constraint = pyo.Constraint(
+            expr=specific_electric_energy_consumption
+            == self.aggregate_flow_electricity
+            / pyo.units.convert(flow_rate, to_units=pyo.units.m**3 / pyo.units.hr)
+        )
 
-        self.add_component("specific_electric_energy_consumption_constraint", specific_electric_energy_consumption_constraint)
+        self.add_component(
+            "specific_electric_energy_consumption_constraint",
+            specific_electric_energy_consumption_constraint,
+        )
 
-    def add_specific_thermal_energy_consumption(
-        self, flow_rate
-    ):
+    def add_specific_thermal_energy_consumption(self, flow_rate):
         """
         Add specific thermal energy consumption (kWh/m**3) to costing block.
         Args:
@@ -345,16 +384,25 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
                         calculating specific energy consumption
         """
 
-        specific_thermal_energy_consumption = pyo.Var(initialize=100, doc=f"Specific thermal energy consumption based on flow {flow_rate.name}")
+        specific_thermal_energy_consumption = pyo.Var(
+            initialize=100,
+            doc=f"Specific thermal energy consumption based on flow {flow_rate.name}",
+        )
 
-        self.add_component("specific_thermal_energy_consumption", specific_thermal_energy_consumption)
+        self.add_component(
+            "specific_thermal_energy_consumption", specific_thermal_energy_consumption
+        )
 
-        specific_thermal_energy_consumption_constraint = pyo.Constraint(expr=specific_thermal_energy_consumption==self.aggregate_flow_heat
-                / pyo.units.convert(
-                    flow_rate, to_units=pyo.units.m**3 / pyo.units.hr
-                ))
+        specific_thermal_energy_consumption_constraint = pyo.Constraint(
+            expr=specific_thermal_energy_consumption
+            == self.aggregate_flow_heat
+            / pyo.units.convert(flow_rate, to_units=pyo.units.m**3 / pyo.units.hr)
+        )
 
-        self.add_component("specific_thermal_energy_consumption_constraint", specific_thermal_energy_consumption_constraint)
+        self.add_component(
+            "specific_thermal_energy_consumption_constraint",
+            specific_thermal_energy_consumption_constraint,
+        )
 
     def add_defined_flow(self, flow_name, flow_cost):
         """
@@ -390,14 +438,18 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
         try:
             treat_cost = self.parent_block().treatment.costing
         except:
-            raise Exception("SETO integrated models require separate treatment and energy costing blocks.")
+            raise Exception(
+                "SETO integrated models require separate treatment and energy costing blocks."
+            )
         return treat_cost
 
     def _get_energy_cost_block(self):
         try:
             en_cost = self.parent_block().energy.costing
         except:
-            raise Exception("SETO integrated models require separate treatment and energy costing blocks.")
+            raise Exception(
+                "SETO integrated models require separate treatment and energy costing blocks."
+            )
         return en_cost
 
     def _get_pysam(self):
@@ -405,13 +457,10 @@ class SETOWaterTAPCostingData(FlowsheetCostingBlockData):
         for k, v in vars(self.model()).items():
             if isinstance(v, PySAMWaterTAP):
                 pysam_block_test_lst.append(k)
-        
+
         if len(pysam_block_test_lst) != 1:
             raise Exception("There is no instance of PySAMWaterTAP on this model.")
-        
+
         else:
             pysam = getattr(self.model(), pysam_block_test_lst[0])
             return pysam
-        
-        
-

--- a/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
@@ -827,7 +827,9 @@ class LTMEDData(UnitModelBlockData):
         iscale.constraint_scaling_transform(self.eq_steam_mass_flow, sf)
 
         sf = iscale.get_scaling_factor(self.specific_thermal_energy_consumption)
-        iscale.constraint_scaling_transform(self.eq_specific_thermal_energy_consumption, sf)
+        iscale.constraint_scaling_transform(
+            self.eq_specific_thermal_energy_consumption, sf
+        )
 
         sf = iscale.get_scaling_factor(self.thermal_power_requirement)
         iscale.constraint_scaling_transform(self.eq_thermal_power_requirement, sf)

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_lt_med_surrogate.py
@@ -31,6 +31,7 @@ from idaes.core.util.scaling import (
 # Get default solver for testing
 solver = get_solver()
 
+
 class TestLTMED:
     @pytest.fixture(scope="class")
     def LT_MED_frame(self):


### PR DESCRIPTION
Improvements to costing approach for SETO-WaterTAP:

- Adds separate ``SETOSystemCosting`` class to aggregate system treatment and energy costs.
- Change ``factor_capital_annualization`` from being a fixed parameter to being calculated from an interest rate (``wacc`` - weighted average cost of capital) 
- Add helper functions for adding LCOW and LCOE calculations
- Separate methods for specific cost of electric energy and specific cost of thermal energy.
- Adds ``TreatmentCosting`` and ``EnergyCosting`` classes that inherit from ``SETOWaterTAPCosting`` (and are identical at this point).
- Adds USD2021 to units registry