### PR TITLE
Remove unused import that now has a different path in watertap

### DIFF
--- a/src/watertap_contrib/seto/analysis/net_metering/PV_RO.py
+++ b/src/watertap_contrib/seto/analysis/net_metering/PV_RO.py
@@ -34,8 +34,6 @@ from watertap.unit_models.reverse_osmosis_0D import (
 from watertap.examples.flowsheets.RO_with_energy_recovery.RO_with_energy_recovery import (
     calculate_operating_pressure,
 )
-from watertap.core.util.infeasible import *
-
 from watertap_contrib.seto.analysis.net_metering.util import (
     display_ro_pv_results,
     display_pv_results,


### PR DESCRIPTION
I figured I'd make this a quick PR to resolve test failures although I already addressed this issue on draft PR #30. This PR simply removes the import from `watertap.core.util.infeasible` which is now located in `watertap.core.util.model_diagnostics.infeasible`