### PR TITLE
Update watertap dependency to match tag pr967 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "watertap @ https://github.com/watertap-org/watertap/archive/refs/tags/pr967.zip",
-
         "pytest >= 7",
         "nrel-pysam == 3.0.2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
     author="WaterTAP-SETO contributors",
     python_requires=">=3.8",
     install_requires=[
-        "watertap @ https://github.com/watertap-org/watertap/archive/main.zip",
+        "watertap @ https://github.com/watertap-org/watertap/archive/refs/tags/pr967.zip",
+
         "pytest >= 7",
         "nrel-pysam == 3.0.2",
     ],


### PR DESCRIPTION
Instead of depending on watertap main, which keeps breaking our tests, i made a tag to PR #967 on the WaterTAP repo to serve as a checkpoint to depend on in the interim. That way, new changes on watertap won't break our tests, and we can adapt as needed in a more controlled fashion.