### PR TITLE
Modify LT-MED and add interpolation for LT-MED and MED-TVC

### DIFF
--- a/src/watertap_contrib/seto/costing/units/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/costing/units/lt_med_surrogate.py
@@ -37,13 +37,6 @@ def build_lt_med_surrogate_cost_param_block(blk):
         doc="Fraction of capital cost for insurance",
     )
 
-    blk.cost_storage_per_kwh = pyo.Var(
-        initialize=26,
-        units=costing.base_currency / pyo.units.kWh,
-        bounds=(0, None),
-        doc="Cost of thermal storage per kWh",
-    )
-
     blk.cost_chemicals_per_vol_dist = pyo.Var(
         initialize=0.04,
         units=costing.base_currency / pyo.units.m**3,
@@ -152,31 +145,6 @@ def cost_lt_med_surrogate(blk):
         doc="MED system cost per m3/day distillate",
     )
 
-    blk.heat_exchanger_specific_area = pyo.Var(
-        initialize=100,
-        units=pyo.units.m**2 / (pyo.units.kg / pyo.units.s),
-        doc="Specific heat exchanger area",
-    )
-
-    blk.thermal_storage_capacity = pyo.Var(
-        initialize=5,
-        units=pyo.units.kWh,
-        doc="Thermal storage capacity",
-    )
-
-    blk.heat_exchanger_specific_area_constraint = pyo.Constraint(
-        expr=blk.heat_exchanger_specific_area
-        == pyo.units.convert(
-            lt_med.specific_area / feed.dens_mass_phase["Liq"],
-            to_units=(pyo.units.m**2 * pyo.units.s) / pyo.units.kg,
-        )
-    )
-
-    blk.thermal_storage_capacity_constraint = pyo.Constraint(
-        expr=blk.thermal_storage_capacity
-        == lt_med.thermal_power_requirement * lt_med_params.hours_thermal_storage
-    )
-
     blk.capacity = pyo.units.convert(
         dist.flow_vol_phase["Liq"], to_units=pyo.units.m**3 / pyo.units.day
     )
@@ -206,7 +174,7 @@ def cost_lt_med_surrogate(blk):
                 lt_med_params.cost_fraction_evaporator
                 * (
                     (
-                        blk.heat_exchanger_specific_area
+                        lt_med.specific_area_per_kg_s
                         / lt_med_params.heat_exchanger_ref_area
                     )
                     ** lt_med_params.heat_exchanger_exp
@@ -223,7 +191,6 @@ def cost_lt_med_surrogate(blk):
     blk.capital_cost_constraint = pyo.Constraint(
         expr=blk.capital_cost
         == blk.total_system_cost
-        + lt_med_params.cost_storage_per_kwh * blk.thermal_storage_capacity
     )
 
     blk.fixed_operating_cost_constraint = pyo.Constraint(

--- a/src/watertap_contrib/seto/costing/units/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/costing/units/lt_med_surrogate.py
@@ -189,8 +189,7 @@ def cost_lt_med_surrogate(blk):
     )
 
     blk.capital_cost_constraint = pyo.Constraint(
-        expr=blk.capital_cost
-        == blk.total_system_cost
+        expr=blk.capital_cost == blk.total_system_cost
     )
 
     blk.fixed_operating_cost_constraint = pyo.Constraint(

--- a/src/watertap_contrib/seto/costing/units/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/costing/units/lt_med_surrogate.py
@@ -121,12 +121,6 @@ def cost_lt_med_surrogate(blk):
     brine = lt_med.brine_props[0]
     base_currency = blk.config.flowsheet_costing_block.base_currency
 
-    blk.total_system_cost = pyo.Var(
-        initialize=100,
-        units=base_currency,
-        doc="MED system cost",
-    )
-
     blk.membrane_system_cost = pyo.Var(
         initialize=100,
         units=base_currency,
@@ -183,13 +177,9 @@ def cost_lt_med_surrogate(blk):
         )
     )
 
-    blk.total_system_cost_constraint = pyo.Constraint(
-        expr=blk.total_system_cost
-        == blk.membrane_system_cost + blk.evaporator_system_cost
-    )
-
     blk.capital_cost_constraint = pyo.Constraint(
-        expr=blk.capital_cost == blk.total_system_cost
+        expr=blk.capital_cost
+        == blk.membrane_system_cost + blk.evaporator_system_cost
     )
 
     blk.fixed_operating_cost_constraint = pyo.Constraint(
@@ -200,7 +190,7 @@ def cost_lt_med_surrogate(blk):
             + lt_med_params.cost_labor_per_vol_dist
             + lt_med_params.cost_misc_per_vol_dist
         )
-        + blk.total_system_cost
+        + blk.capital_cost
         * (
             lt_med_params.cost_fraction_maintenance
             + lt_med_params.cost_fraction_insurance

--- a/src/watertap_contrib/seto/costing/units/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/costing/units/lt_med_surrogate.py
@@ -178,8 +178,7 @@ def cost_lt_med_surrogate(blk):
     )
 
     blk.capital_cost_constraint = pyo.Constraint(
-        expr=blk.capital_cost
-        == blk.membrane_system_cost + blk.evaporator_system_cost
+        expr=blk.capital_cost == blk.membrane_system_cost + blk.evaporator_system_cost
     )
 
     blk.fixed_operating_cost_constraint = pyo.Constraint(

--- a/src/watertap_contrib/seto/costing/units/med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/costing/units/med_tvc_surrogate.py
@@ -115,12 +115,6 @@ def cost_med_tvc_surrogate(blk):
     brine = med_tvc.brine_props[0]
     base_currency = blk.config.flowsheet_costing_block.base_currency
 
-    blk.total_system_cost = pyo.Var(
-        initialize=100,
-        units=base_currency,
-        doc="MED system cost",
-    )
-
     blk.membrane_system_cost = pyo.Var(
         initialize=100,
         units=base_currency,
@@ -177,13 +171,9 @@ def cost_med_tvc_surrogate(blk):
         )
     )
 
-    blk.total_system_cost_constraint = pyo.Constraint(
-        expr=blk.total_system_cost
-        == blk.membrane_system_cost + blk.evaporator_system_cost
-    )
-
     blk.capital_cost_constraint = pyo.Constraint(
-        expr=blk.capital_cost == blk.total_system_cost
+        expr=blk.capital_cost
+        == blk.membrane_system_cost + blk.evaporator_system_cost
     )
 
     blk.fixed_operating_cost_constraint = pyo.Constraint(
@@ -194,7 +184,7 @@ def cost_med_tvc_surrogate(blk):
             + med_tvc_params.cost_labor_per_vol_dist
             + med_tvc_params.cost_misc_per_vol_dist
         )
-        + blk.total_system_cost
+        + blk.capital_cost
         * (
             med_tvc_params.cost_fraction_maintenance
             + med_tvc_params.cost_fraction_insurance

--- a/src/watertap_contrib/seto/costing/units/med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/costing/units/med_tvc_surrogate.py
@@ -172,8 +172,7 @@ def cost_med_tvc_surrogate(blk):
     )
 
     blk.capital_cost_constraint = pyo.Constraint(
-        expr=blk.capital_cost
-        == blk.membrane_system_cost + blk.evaporator_system_cost
+        expr=blk.capital_cost == blk.membrane_system_cost + blk.evaporator_system_cost
     )
 
     blk.fixed_operating_cost_constraint = pyo.Constraint(

--- a/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
@@ -113,7 +113,7 @@ class LTMEDData(UnitModelBlockData):
         "number_effects",
         ConfigValue(
             default=12,
-            domain=In([i for i in range(3,15)]),
+            domain=In([i for i in range(3, 15)]),
             description="Number of effects of the MED_TVC system",
             doc="""A ConfigBlock specifying the number of effects, which should be an interger between 8 to 16.""",
         ),
@@ -256,6 +256,7 @@ class LTMEDData(UnitModelBlockData):
             doc="Material properties of heating steam",
             **tmp_dict,
         )
+
         @self.Constraint(doc="Flow rate of liquid heating steam is zero")
         def eq_heating_steam_liquid_mass(b):
             return b.steam_props[0].flow_mass_phase_comp["Liq", "H2O"] == 0
@@ -290,6 +291,7 @@ class LTMEDData(UnitModelBlockData):
         """
         Isobaric
         """
+
         @self.Constraint(self.flowsheet().config.time, doc="Isobaric")
         def eq_feed_to_distillate_isobaric(b, t):
             return b.feed_props[t].pressure == b.distillate_props[t].pressure
@@ -382,8 +384,7 @@ class LTMEDData(UnitModelBlockData):
                 + feed_conc_ppm
                 * self.recovery_vol_phase[0, "Liq"]
                 * gain_output_ratio_coeffs[num_effect][2]
-                + self.temp_last_effect
-                * gain_output_ratio_coeffs[num_effect][3]
+                + self.temp_last_effect * gain_output_ratio_coeffs[num_effect][3]
                 + self.temp_last_effect
                 * feed_conc_ppm
                 * gain_output_ratio_coeffs[num_effect][4]
@@ -391,9 +392,7 @@ class LTMEDData(UnitModelBlockData):
                 * self.recovery_vol_phase[0, "Liq"]
                 * gain_output_ratio_coeffs[num_effect][5]
                 + temp_steam * gain_output_ratio_coeffs[num_effect][6]
-                + temp_steam
-                * feed_conc_ppm
-                * gain_output_ratio_coeffs[num_effect][7]
+                + temp_steam * feed_conc_ppm * gain_output_ratio_coeffs[num_effect][7]
                 + temp_steam
                 * self.recovery_vol_phase[0, "Liq"]
                 * gain_output_ratio_coeffs[num_effect][8]
@@ -402,12 +401,10 @@ class LTMEDData(UnitModelBlockData):
                 * gain_output_ratio_coeffs[num_effect][9]
                 + 1 * gain_output_ratio_coeffs[num_effect][10]
                 + temp_steam**2 * gain_output_ratio_coeffs[num_effect][11]
-                + self.temp_last_effect**2
-                * gain_output_ratio_coeffs[num_effect][12]
+                + self.temp_last_effect**2 * gain_output_ratio_coeffs[num_effect][12]
                 + self.recovery_vol_phase[0, "Liq"] ** 2
                 * gain_output_ratio_coeffs[num_effect][13]
-                + feed_conc_ppm**2
-                * gain_output_ratio_coeffs[num_effect][14]
+                + feed_conc_ppm**2 * gain_output_ratio_coeffs[num_effect][14]
             )
 
         specific_area_coeffs = self._get_specific_area_coeffs()
@@ -417,8 +414,7 @@ class LTMEDData(UnitModelBlockData):
             if num_effect in [3, 6, 9]:
                 return (
                     feed_conc_ppm * specific_area_coeffs[num_effect][0]
-                    + feed_conc_ppm**2
-                    * specific_area_coeffs[num_effect][1]
+                    + feed_conc_ppm**2 * specific_area_coeffs[num_effect][1]
                     + self.recovery_vol_phase[0, "Liq"]
                     * specific_area_coeffs[num_effect][2]
                     + self.recovery_vol_phase[0, "Liq"]
@@ -432,8 +428,7 @@ class LTMEDData(UnitModelBlockData):
                     + self.recovery_vol_phase[0, "Liq"] ** 2
                     * feed_conc_ppm
                     * specific_area_coeffs[num_effect][6]
-                    + self.temp_last_effect
-                    * specific_area_coeffs[num_effect][7]
+                    + self.temp_last_effect * specific_area_coeffs[num_effect][7]
                     + self.temp_last_effect
                     * feed_conc_ppm
                     * specific_area_coeffs[num_effect][8]
@@ -450,8 +445,7 @@ class LTMEDData(UnitModelBlockData):
                     + self.temp_last_effect
                     * self.recovery_vol_phase[0, "Liq"] ** 2
                     * specific_area_coeffs[num_effect][12]
-                    + self.temp_last_effect**2
-                    * specific_area_coeffs[num_effect][13]
+                    + self.temp_last_effect**2 * specific_area_coeffs[num_effect][13]
                     + self.temp_last_effect**2
                     * feed_conc_ppm
                     * specific_area_coeffs[num_effect][14]
@@ -459,9 +453,7 @@ class LTMEDData(UnitModelBlockData):
                     * self.recovery_vol_phase[0, "Liq"]
                     * specific_area_coeffs[num_effect][15]
                     + temp_steam * specific_area_coeffs[num_effect][16]
-                    + temp_steam
-                    * feed_conc_ppm
-                    * specific_area_coeffs[num_effect][17]
+                    + temp_steam * feed_conc_ppm * specific_area_coeffs[num_effect][17]
                     + temp_steam
                     * feed_conc_ppm**2
                     * specific_area_coeffs[num_effect][18]
@@ -501,21 +493,17 @@ class LTMEDData(UnitModelBlockData):
                     * specific_area_coeffs[num_effect][29]
                     + 1 * specific_area_coeffs[num_effect][30]
                     + temp_steam**3 * specific_area_coeffs[num_effect][31]
-                    + self.temp_last_effect**3
-                    * specific_area_coeffs[num_effect][32]
+                    + self.temp_last_effect**3 * specific_area_coeffs[num_effect][32]
                     + self.recovery_vol_phase[0, "Liq"] ** 3
                     * specific_area_coeffs[num_effect][33]
-                    + feed_conc_ppm**3
-                    * specific_area_coeffs[num_effect][34]
+                    + feed_conc_ppm**3 * specific_area_coeffs[num_effect][34]
                 )
 
             else:
                 return (
                     feed_conc_ppm * specific_area_coeffs[num_effect][0]
-                    + feed_conc_ppm**2
-                    * specific_area_coeffs[num_effect][1]
-                    + feed_conc_ppm**3
-                    * specific_area_coeffs[num_effect][2]
+                    + feed_conc_ppm**2 * specific_area_coeffs[num_effect][1]
+                    + feed_conc_ppm**3 * specific_area_coeffs[num_effect][2]
                     + self.recovery_vol_phase[0, "Liq"]
                     * specific_area_coeffs[num_effect][3]
                     + self.recovery_vol_phase[0, "Liq"]
@@ -540,8 +528,7 @@ class LTMEDData(UnitModelBlockData):
                     + self.recovery_vol_phase[0, "Liq"] ** 3
                     * feed_conc_ppm
                     * specific_area_coeffs[num_effect][11]
-                    + self.temp_last_effect
-                    * specific_area_coeffs[num_effect][12]
+                    + self.temp_last_effect * specific_area_coeffs[num_effect][12]
                     + self.temp_last_effect
                     * feed_conc_ppm
                     * specific_area_coeffs[num_effect][13]
@@ -572,8 +559,7 @@ class LTMEDData(UnitModelBlockData):
                     + self.temp_last_effect
                     * self.recovery_vol_phase[0, "Liq"] ** 3
                     * specific_area_coeffs[num_effect][21]
-                    + self.temp_last_effect**2
-                    * specific_area_coeffs[num_effect][22]
+                    + self.temp_last_effect**2 * specific_area_coeffs[num_effect][22]
                     + self.temp_last_effect**2
                     * feed_conc_ppm
                     * specific_area_coeffs[num_effect][23]
@@ -590,8 +576,7 @@ class LTMEDData(UnitModelBlockData):
                     + self.temp_last_effect**2
                     * self.recovery_vol_phase[0, "Liq"] ** 2
                     * specific_area_coeffs[num_effect][27]
-                    + self.temp_last_effect**3
-                    * specific_area_coeffs[num_effect][28]
+                    + self.temp_last_effect**3 * specific_area_coeffs[num_effect][28]
                     + self.temp_last_effect**3
                     * feed_conc_ppm
                     * specific_area_coeffs[num_effect][29]
@@ -599,9 +584,7 @@ class LTMEDData(UnitModelBlockData):
                     * self.recovery_vol_phase[0, "Liq"]
                     * specific_area_coeffs[num_effect][30]
                     + temp_steam * specific_area_coeffs[num_effect][31]
-                    + temp_steam
-                    * feed_conc_ppm
-                    * specific_area_coeffs[num_effect][32]
+                    + temp_steam * feed_conc_ppm * specific_area_coeffs[num_effect][32]
                     + temp_steam
                     * feed_conc_ppm**2
                     * specific_area_coeffs[num_effect][33]
@@ -710,64 +693,62 @@ class LTMEDData(UnitModelBlockData):
                     * specific_area_coeffs[num_effect][64]
                     + 1 * specific_area_coeffs[num_effect][65]
                     + temp_steam**4 * specific_area_coeffs[num_effect][66]
-                    + self.temp_last_effect**4
-                    * specific_area_coeffs[num_effect][67]
+                    + self.temp_last_effect**4 * specific_area_coeffs[num_effect][67]
                     + self.recovery_vol_phase[0, "Liq"] ** 4
                     * specific_area_coeffs[num_effect][68]
-                    + feed_conc_ppm**4
-                    * specific_area_coeffs[num_effect][69]
+                    + feed_conc_ppm**4 * specific_area_coeffs[num_effect][69]
                 )
 
         # Surrogate equations were built for 3,6,9,12,14 effects
         # For intermediate number of effects (4,5,7,8,10,11,13), linear interpolation is adopted
         @self.Constraint(doc="Gain output ratio surrogate equation")
         def eq_gain_output_ratio(b):
-            if b.config.number_effects in [3,6,9,12,14]:
-                return (
-                    b.gain_output_ratio
-                    == _get_gain_output_ratio(b.config.number_effects)
+            if b.config.number_effects in [3, 6, 9, 12, 14]:
+                return b.gain_output_ratio == _get_gain_output_ratio(
+                    b.config.number_effects
                 )
-            else: # number_effects in [4,5,7,8,10,11,13]
+            else:  # number_effects in [4,5,7,8,10,11,13]
                 # find out the closest numbers of effects that have a surrogate equation
-                interp_effects, i = [3,6,9,12,14], 1
+                interp_effects, i = [3, 6, 9, 12, 14], 1
                 while interp_effects[i] < b.config.number_effects:
                     i += 1
-                interp_point1, interp_point2 = interp_effects[i-1], interp_effects[i]
-                
+                interp_point1, interp_point2 = interp_effects[i - 1], interp_effects[i]
+
                 # implement linear interpolation using 2 points
-                return (
-                    b.gain_output_ratio
-                    == _get_gain_output_ratio(interp_point1) 
-                    * (interp_point2 - b.config.number_effects)
-                    / (interp_point2 - interp_point1)
-                    +  _get_gain_output_ratio(interp_point2)
-                    * (b.config.number_effects - interp_point1)
-                    / (interp_point2 - interp_point1)
-                )            
+                return b.gain_output_ratio == _get_gain_output_ratio(interp_point1) * (
+                    interp_point2 - b.config.number_effects
+                ) / (interp_point2 - interp_point1) + _get_gain_output_ratio(
+                    interp_point2
+                ) * (
+                    b.config.number_effects - interp_point1
+                ) / (
+                    interp_point2 - interp_point1
+                )
 
         @self.Constraint(doc="Specific area surrogate equation")
         def eq_specific_area_per_m3_day(b):
-            if b.config.number_effects in [3,6,9,12,14]:
-                return (
-                    b.specific_area_per_m3_day
-                    == _get_specific_area(b.config.number_effects)
+            if b.config.number_effects in [3, 6, 9, 12, 14]:
+                return b.specific_area_per_m3_day == _get_specific_area(
+                    b.config.number_effects
                 )
-            else: # number_effects in [4,5,7,8,10,11,13]
+            else:  # number_effects in [4,5,7,8,10,11,13]
                 # find out the closest numbers of effects that have a surrogate equation
-                interp_effects, i = [3,6,9,12,14], 1
+                interp_effects, i = [3, 6, 9, 12, 14], 1
                 while interp_effects[i] < b.config.number_effects:
                     i += 1
-                interp_point1, interp_point2 = interp_effects[i-1], interp_effects[i]
+                interp_point1, interp_point2 = interp_effects[i - 1], interp_effects[i]
 
                 # implement linear interpolation using 2 points
-                return (
-                    b.specific_area_per_m3_day
-                    == _get_specific_area(interp_point1) 
-                    * (interp_point2 - b.config.number_effects)
-                    / (interp_point2 - interp_point1)
-                    +  _get_specific_area(interp_point2)
-                    * (b.config.number_effects - interp_point1)
-                    / (interp_point2 - interp_point1)
+                return b.specific_area_per_m3_day == _get_specific_area(
+                    interp_point1
+                ) * (interp_point2 - b.config.number_effects) / (
+                    interp_point2 - interp_point1
+                ) + _get_specific_area(
+                    interp_point2
+                ) * (
+                    b.config.number_effects - interp_point1
+                ) / (
+                    interp_point2 - interp_point1
                 )
 
         @self.Constraint(doc="Convert specific area to m2/kg/s for CAPEX calculation")
@@ -776,7 +757,6 @@ class LTMEDData(UnitModelBlockData):
                 b.specific_area_per_m3_day / b.feed_props[0].dens_mass_phase["Liq"],
                 to_units=pyunits.m**2 / pyunits.kg * pyunits.s,
             )
-
 
         # Steam flow rate calculation
         @self.Constraint(doc="Steam flow rate")
@@ -1032,7 +1012,9 @@ class LTMEDData(UnitModelBlockData):
         sf = iscale.get_scaling_factor(self.cooling_out_props[0].temperature)
         iscale.constraint_scaling_transform(self.eq_cooling_temp, sf)
 
-        sf = iscale.get_scaling_factor(self.steam_props[0].flow_mass_phase_comp["Liq", "H2O"])
+        sf = iscale.get_scaling_factor(
+            self.steam_props[0].flow_mass_phase_comp["Liq", "H2O"]
+        )
         iscale.constraint_scaling_transform(self.eq_heating_steam_liquid_mass, sf)
 
         sf = iscale.get_scaling_factor(
@@ -1171,7 +1153,7 @@ class LTMEDData(UnitModelBlockData):
             ],
             9: [
                 1.67e-06,
-                5.9507846+1e-3,
+                5.9507846 + 1e-3,
                 -3.94e-06,
                 0.012607651,
                 -5.50e-08,

--- a/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
@@ -115,7 +115,7 @@ class LTMEDData(UnitModelBlockData):
             default=12,
             domain=In([i for i in range(3, 15)]),
             description="Number of effects of the MED_TVC system",
-            doc="""A ConfigBlock specifying the number of effects, which should be an interger between 8 to 16.""",
+            doc="""A ConfigBlock specifying the number of effects, which should be an integer between 8 to 16.""",
         ),
     )
 

--- a/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
@@ -125,8 +125,10 @@ class LTMEDData(UnitModelBlockData):
         self.scaling_factor = Suffix(direction=Suffix.EXPORT)
 
         # Check if the number of effects is valid
-        if self.config.number_effects not in [i for i in range(3,15)]:
-            raise ConfigurationError("The number of effects should be an integer between 3 to 14")
+        if self.config.number_effects not in [i for i in range(3, 15)]:
+            raise ConfigurationError(
+                "The number of effects should be an integer between 3 to 14"
+            )
 
         """
         Add system configurations
@@ -387,7 +389,7 @@ class LTMEDData(UnitModelBlockData):
                 return b.gain_output_ratio == self._get_gain_output_ratio(
                     b.config.number_effects
                 )
-            else: # b.config.number_effects in [4, 5, 7, 8, 10, 11, 13]:
+            else:  # b.config.number_effects in [4, 5, 7, 8, 10, 11, 13]:
                 # find out the closest numbers of effects that have a surrogate equation
                 interp_effects, i = [3, 6, 9, 12, 14], 1
                 while interp_effects[i] < b.config.number_effects:
@@ -395,14 +397,14 @@ class LTMEDData(UnitModelBlockData):
                 interp_point1, interp_point2 = interp_effects[i - 1], interp_effects[i]
 
                 # implement linear interpolation using 2 points
-                return b.gain_output_ratio == self._get_gain_output_ratio(interp_point1) * (
+                return b.gain_output_ratio * (
+                    interp_point2 - interp_point1
+                ) == self._get_gain_output_ratio(interp_point1) * (
                     interp_point2 - b.config.number_effects
-                ) / (interp_point2 - interp_point1) + self._get_gain_output_ratio(
+                ) + self._get_gain_output_ratio(
                     interp_point2
                 ) * (
                     b.config.number_effects - interp_point1
-                ) / (
-                    interp_point2 - interp_point1
                 )
 
         @self.Constraint(doc="Specific area surrogate equation")
@@ -411,7 +413,7 @@ class LTMEDData(UnitModelBlockData):
                 return b.specific_area_per_m3_day == self._get_specific_area(
                     b.config.number_effects
                 )
-            else: # b.config.number_effects in [4, 5, 7, 8, 10, 11, 13]:
+            else:  # b.config.number_effects in [4, 5, 7, 8, 10, 11, 13]:
                 # find out the closest numbers of effects that have a surrogate equation
                 interp_effects, i = [3, 6, 9, 12, 14], 1
                 while interp_effects[i] < b.config.number_effects:
@@ -419,16 +421,14 @@ class LTMEDData(UnitModelBlockData):
                 interp_point1, interp_point2 = interp_effects[i - 1], interp_effects[i]
 
                 # implement linear interpolation using 2 points
-                return b.specific_area_per_m3_day == self._get_specific_area(
-                    interp_point1
-                ) * (interp_point2 - b.config.number_effects) / (
+                return b.specific_area_per_m3_day * (
                     interp_point2 - interp_point1
+                ) == self._get_specific_area(interp_point1) * (
+                    interp_point2 - b.config.number_effects
                 ) + self._get_specific_area(
                     interp_point2
                 ) * (
                     b.config.number_effects - interp_point1
-                ) / (
-                    interp_point2 - interp_point1
                 )
 
         @self.Constraint(doc="Convert specific area to m2/kg/s for CAPEX calculation")
@@ -1155,7 +1155,9 @@ class LTMEDData(UnitModelBlockData):
             * self.recovery_vol_phase[0, "Liq"]
             * self.gain_output_ratio_coeffs[num_effect][5]
             + self.temp_steam * self.gain_output_ratio_coeffs[num_effect][6]
-            + self.temp_steam * self.feed_conc_ppm * self.gain_output_ratio_coeffs[num_effect][7]
+            + self.temp_steam
+            * self.feed_conc_ppm
+            * self.gain_output_ratio_coeffs[num_effect][7]
             + self.temp_steam
             * self.recovery_vol_phase[0, "Liq"]
             * self.gain_output_ratio_coeffs[num_effect][8]
@@ -1214,7 +1216,9 @@ class LTMEDData(UnitModelBlockData):
                 * self.recovery_vol_phase[0, "Liq"]
                 * self.specific_area_coeffs[num_effect][15]
                 + self.temp_steam * self.specific_area_coeffs[num_effect][16]
-                + self.temp_steam * self.feed_conc_ppm * self.specific_area_coeffs[num_effect][17]
+                + self.temp_steam
+                * self.feed_conc_ppm
+                * self.specific_area_coeffs[num_effect][17]
                 + self.temp_steam
                 * self.feed_conc_ppm**2
                 * self.specific_area_coeffs[num_effect][18]
@@ -1345,7 +1349,9 @@ class LTMEDData(UnitModelBlockData):
                 * self.recovery_vol_phase[0, "Liq"]
                 * self.specific_area_coeffs[num_effect][30]
                 + self.temp_steam * self.specific_area_coeffs[num_effect][31]
-                + self.temp_steam * self.feed_conc_ppm * self.specific_area_coeffs[num_effect][32]
+                + self.temp_steam
+                * self.feed_conc_ppm
+                * self.specific_area_coeffs[num_effect][32]
                 + self.temp_steam
                 * self.feed_conc_ppm**2
                 * self.specific_area_coeffs[num_effect][33]

--- a/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
@@ -115,7 +115,7 @@ class LTMEDData(UnitModelBlockData):
             default=12,
             domain=In([i for i in range(3, 15)]),
             description="Number of effects of the MED_TVC system",
-            doc="""A ConfigBlock specifying the number of effects, which should be an integer between 8 to 16.""",
+            doc="""A ConfigBlock specifying the number of effects, which should be an integer between 3 to 14.""",
         ),
     )
 

--- a/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
@@ -193,9 +193,7 @@ class LTMEDData(UnitModelBlockData):
             )
 
         # Salinity in distillate is zero
-        @self.Constraint(doc="distillate salinity")
-        def eq_distillate_salinity(b):
-            return b.distillate_props[0].flow_mass_phase_comp["Liq", "TDS"] == 0
+        self.distillate_props[0].flow_mass_phase_comp["Liq", "TDS"].fix(0)
 
         """
         Add block for brine
@@ -707,7 +705,7 @@ class LTMEDData(UnitModelBlockData):
                 return b.gain_output_ratio == _get_gain_output_ratio(
                     b.config.number_effects
                 )
-            else:  # number_effects in [4,5,7,8,10,11,13]
+            elif b.config.number_effects in [4, 5, 7, 8, 10, 11, 13]:
                 # find out the closest numbers of effects that have a surrogate equation
                 interp_effects, i = [3, 6, 9, 12, 14], 1
                 while interp_effects[i] < b.config.number_effects:
@@ -724,6 +722,10 @@ class LTMEDData(UnitModelBlockData):
                 ) / (
                     interp_point2 - interp_point1
                 )
+            else:
+                raise Exception(
+                    "Only integers between 3 to 14 are allowed for the number of effects"
+                )
 
         @self.Constraint(doc="Specific area surrogate equation")
         def eq_specific_area_per_m3_day(b):
@@ -731,7 +733,7 @@ class LTMEDData(UnitModelBlockData):
                 return b.specific_area_per_m3_day == _get_specific_area(
                     b.config.number_effects
                 )
-            else:  # number_effects in [4,5,7,8,10,11,13]
+            elif b.config.number_effects in [4, 5, 7, 8, 10, 11, 13]:
                 # find out the closest numbers of effects that have a surrogate equation
                 interp_effects, i = [3, 6, 9, 12, 14], 1
                 while interp_effects[i] < b.config.number_effects:
@@ -749,6 +751,10 @@ class LTMEDData(UnitModelBlockData):
                     b.config.number_effects - interp_point1
                 ) / (
                     interp_point2 - interp_point1
+                )
+            else:
+                raise Exception(
+                    "Only integers between 3 to 14 are allowed for the number of effects"
                 )
 
         @self.Constraint(doc="Convert specific area to m2/kg/s for CAPEX calculation")
@@ -1003,11 +1009,6 @@ class LTMEDData(UnitModelBlockData):
 
         sf = iscale.get_scaling_factor(self.distillate_props[0].temperature)
         iscale.constraint_scaling_transform(self.eq_distillate_temp, sf)
-
-        sf = iscale.get_scaling_factor(
-            self.distillate_props[0].flow_mass_phase_comp["Liq", "TDS"]
-        )
-        iscale.constraint_scaling_transform(self.eq_distillate_salinity, sf)
 
         sf = iscale.get_scaling_factor(self.cooling_out_props[0].temperature)
         iscale.constraint_scaling_transform(self.eq_cooling_temp, sf)

--- a/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
@@ -31,6 +31,7 @@ from idaes.core import (
     UnitModelBlockData,
     useDefault,
 )
+from idaes.core.util.model_statistics import degrees_of_freedom
 from idaes.core.solvers.get_solver import get_solver
 from idaes.core.util.config import is_physical_parameter_block
 from idaes.core.util.exceptions import ConfigurationError, InitializationError
@@ -71,7 +72,7 @@ class LTMEDData(UnitModelBlockData):
         ),
     )
     CONFIG.declare(
-        "property_package_water",
+        "property_package_liquid",
         ConfigValue(
             default=useDefault,
             domain=is_physical_parameter_block,
@@ -84,7 +85,7 @@ class LTMEDData(UnitModelBlockData):
         ),
     )
     CONFIG.declare(
-        "property_package_steam",
+        "property_package_vapor",
         ConfigValue(
             default=useDefault,
             domain=is_physical_parameter_block,
@@ -108,6 +109,15 @@ class LTMEDData(UnitModelBlockData):
     see property package for documentation.}""",
         ),
     )
+    CONFIG.declare(
+        "number_effects",
+        ConfigValue(
+            default=12,
+            domain=In([i for i in range(3,15)]),
+            description="Number of effects of the MED_TVC system",
+            doc="""A ConfigBlock specifying the number of effects, which should be an interger between 8 to 16.""",
+        ),
+    )
 
     def build(self):
         super().build()
@@ -117,27 +127,22 @@ class LTMEDData(UnitModelBlockData):
         """
         Add system configurations
         """
-        self.number_effects = Param(
-            initialize=12,
-            mutable=True,
-            within=Set(initialize=[3, 6, 9, 12, 14]),
-            units=pyunits.dimensionless,
-            doc="Number of effects",
-        )
-
-        self.delta_T_last_effect = Param(
+        self.delta_T_last_effect = Var(
             initialize=10,
-            mutable=True,
             units=pyunits.K,
             doc="Temperature increase in last effect",
         )
 
-        self.delta_T_cooling_reject = Param(
+        self.delta_T_cooling_reject = Var(
             initialize=-3,
-            mutable=True,
             units=pyunits.K,
             doc="Temperature decrease in cooling reject water",
         )
+
+        # These two variables should be fixed with the default values,
+        # with which the surrogate model was developed
+        self.delta_T_last_effect.fix()
+        self.delta_T_cooling_reject.fix()
 
         self.recovery_vol_phase = Var(
             self.flowsheet().config.time,
@@ -159,10 +164,10 @@ class LTMEDData(UnitModelBlockData):
         """
         tmp_dict = dict(**self.config.property_package_args)
         tmp_dict["has_phase_equilibrium"] = False
-        tmp_dict["parameters"] = self.config.property_package_water
+        tmp_dict["parameters"] = self.config.property_package_liquid
         tmp_dict["defined_state"] = True
 
-        self.feed_props = self.config.property_package_water.state_block_class(
+        self.feed_props = self.config.property_package_liquid.state_block_class(
             self.flowsheet().config.time,
             doc="Material properties of feed water",
             **tmp_dict,
@@ -172,7 +177,7 @@ class LTMEDData(UnitModelBlockData):
         Add block for distillate
         """
         tmp_dict["defined_state"] = False
-        self.distillate_props = self.config.property_package_water.state_block_class(
+        self.distillate_props = self.config.property_package_liquid.state_block_class(
             self.flowsheet().config.time,
             doc="Material properties of distillate",
             **tmp_dict,
@@ -187,11 +192,15 @@ class LTMEDData(UnitModelBlockData):
                 == b.feed_props[0].temperature + b.delta_T_last_effect
             )
 
+        # Salinity in distillate is zero
+        @self.Constraint(doc="distillate salinity")
+        def eq_distillate_salinity(b):
+            return b.distillate_props[0].flow_mass_phase_comp["Liq", "TDS"] == 0
+
         """
         Add block for brine
         """
-
-        self.brine_props = self.config.property_package_water.state_block_class(
+        self.brine_props = self.config.property_package_liquid.state_block_class(
             self.flowsheet().config.time, doc="Material properties of brine", **tmp_dict
         )
 
@@ -213,7 +222,7 @@ class LTMEDData(UnitModelBlockData):
         """
         Add block for reject cooling water
         """
-        self.cooling_out_props = self.config.property_package_water.state_block_class(
+        self.cooling_out_props = self.config.property_package_liquid.state_block_class(
             self.flowsheet().config.time,
             doc="Material properties of cooling reject",
             **tmp_dict,
@@ -239,14 +248,17 @@ class LTMEDData(UnitModelBlockData):
         """
         Add block for heating steam
         """
-        tmp_dict["parameters"] = self.config.property_package_steam
-        tmp_dict["defined_state"] = True
+        tmp_dict["parameters"] = self.config.property_package_vapor
+        tmp_dict["defined_state"] = False
 
-        self.steam_props = self.config.property_package_steam.state_block_class(
+        self.steam_props = self.config.property_package_vapor.state_block_class(
             self.flowsheet().config.time,
             doc="Material properties of heating steam",
             **tmp_dict,
         )
+        @self.Constraint(doc="Flow rate of liquid heating steam is zero")
+        def eq_heating_steam_liquid_mass(b):
+            return b.steam_props[0].flow_mass_phase_comp["Liq", "H2O"] == 0
 
         # Add ports
         self.add_port(name="feed", block=self.feed_props)
@@ -278,7 +290,6 @@ class LTMEDData(UnitModelBlockData):
         """
         Isobaric
         """
-
         @self.Constraint(self.flowsheet().config.time, doc="Isobaric")
         def eq_feed_to_distillate_isobaric(b, t):
             return b.feed_props[t].pressure == b.distillate_props[t].pressure
@@ -301,11 +312,18 @@ class LTMEDData(UnitModelBlockData):
             doc="Thermal power requirement (kW)",
         )
 
-        self.specific_area = Var(
+        self.specific_area_per_m3_day = Var(
             initialize=2,
             bounds=(0, None),
             units=pyunits.m**2 / (pyunits.m**3 / pyunits.d),
             doc="Specific area (m2/m3/day))",
+        )
+
+        self.specific_area_per_kg_s = Var(
+            initialize=400,
+            bounds=(0, None),
+            units=pyunits.m**2 / (pyunits.k / pyunits.s),
+            doc="Specific area (m2/kg/s))",
         )
 
         self.specific_energy_consumption_thermal = Var(
@@ -325,7 +343,7 @@ class LTMEDData(UnitModelBlockData):
         """
         Add Vars for intermediate model variables
         """
-        # TODO: Make Expressions?
+        # Create the total flow rate of brackish/seawater for the calculation of cooling water flow rate
         self.feed_cool_mass_flow = Var(
             initialize=1000,
             bounds=(0, None),
@@ -356,353 +374,409 @@ class LTMEDData(UnitModelBlockData):
         # Surrogate equations for calculating gain output ratio
         gain_output_ratio_coeffs = self._get_gain_output_ratio_coeffs()
 
-        @self.Constraint(doc="Gain output ratio surrogate equation")
-        def eq_gain_output_ratio(b):
+        def _get_gain_output_ratio(num_effect):
             return (
-                b.gain_output_ratio
-                == feed_conc_ppm * gain_output_ratio_coeffs[b.number_effects.value][0]
-                + b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][1]
+                feed_conc_ppm * gain_output_ratio_coeffs[num_effect][0]
+                + self.recovery_vol_phase[0, "Liq"]
+                * gain_output_ratio_coeffs[num_effect][1]
                 + feed_conc_ppm
-                * b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][2]
-                + b.temp_last_effect
-                * gain_output_ratio_coeffs[b.number_effects.value][3]
-                + b.temp_last_effect
+                * self.recovery_vol_phase[0, "Liq"]
+                * gain_output_ratio_coeffs[num_effect][2]
+                + self.temp_last_effect
+                * gain_output_ratio_coeffs[num_effect][3]
+                + self.temp_last_effect
                 * feed_conc_ppm
-                * gain_output_ratio_coeffs[b.number_effects.value][4]
-                + b.temp_last_effect
-                * b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][5]
-                + temp_steam * gain_output_ratio_coeffs[b.number_effects.value][6]
+                * gain_output_ratio_coeffs[num_effect][4]
+                + self.temp_last_effect
+                * self.recovery_vol_phase[0, "Liq"]
+                * gain_output_ratio_coeffs[num_effect][5]
+                + temp_steam * gain_output_ratio_coeffs[num_effect][6]
                 + temp_steam
                 * feed_conc_ppm
-                * gain_output_ratio_coeffs[b.number_effects.value][7]
+                * gain_output_ratio_coeffs[num_effect][7]
                 + temp_steam
-                * b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][8]
+                * self.recovery_vol_phase[0, "Liq"]
+                * gain_output_ratio_coeffs[num_effect][8]
                 + temp_steam
-                * b.temp_last_effect
-                * gain_output_ratio_coeffs[b.number_effects.value][9]
-                + 1 * gain_output_ratio_coeffs[b.number_effects.value][10]
-                + temp_steam**2 * gain_output_ratio_coeffs[b.number_effects.value][11]
-                + b.temp_last_effect**2
-                * gain_output_ratio_coeffs[b.number_effects.value][12]
-                + b.recovery_vol_phase[0, "Liq"] ** 2
-                * gain_output_ratio_coeffs[b.number_effects.value][13]
+                * self.temp_last_effect
+                * gain_output_ratio_coeffs[num_effect][9]
+                + 1 * gain_output_ratio_coeffs[num_effect][10]
+                + temp_steam**2 * gain_output_ratio_coeffs[num_effect][11]
+                + self.temp_last_effect**2
+                * gain_output_ratio_coeffs[num_effect][12]
+                + self.recovery_vol_phase[0, "Liq"] ** 2
+                * gain_output_ratio_coeffs[num_effect][13]
                 + feed_conc_ppm**2
-                * gain_output_ratio_coeffs[b.number_effects.value][14]
+                * gain_output_ratio_coeffs[num_effect][14]
             )
 
         specific_area_coeffs = self._get_specific_area_coeffs()
 
-        @self.Constraint(doc="Specific area surrogate equation")
-        def eq_specific_area(b):
-            if b.number_effects.value in [3, 6, 9]:
+        # Specific area surrogate equation, as a function of the number of effect
+        def _get_specific_area(num_effect):
+            if num_effect in [3, 6, 9]:
                 return (
-                    b.specific_area
-                    == feed_conc_ppm * specific_area_coeffs[b.number_effects.value][0]
+                    feed_conc_ppm * specific_area_coeffs[num_effect][0]
                     + feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][1]
-                    + b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][2]
-                    + b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][1]
+                    + self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][2]
+                    + self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][3]
-                    + b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][3]
+                    + self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][4]
-                    + b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][5]
-                    + b.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][4]
+                    + self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][5]
+                    + self.recovery_vol_phase[0, "Liq"] ** 2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][6]
-                    + b.temp_last_effect
-                    * specific_area_coeffs[b.number_effects.value][7]
-                    + b.temp_last_effect
+                    * specific_area_coeffs[num_effect][6]
+                    + self.temp_last_effect
+                    * specific_area_coeffs[num_effect][7]
+                    + self.temp_last_effect
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][8]
-                    + b.temp_last_effect
+                    * specific_area_coeffs[num_effect][8]
+                    + self.temp_last_effect
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][9]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][10]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][9]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][10]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][11]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][12]
-                    + b.temp_last_effect**2
-                    * specific_area_coeffs[b.number_effects.value][13]
-                    + b.temp_last_effect**2
+                    * specific_area_coeffs[num_effect][11]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][12]
+                    + self.temp_last_effect**2
+                    * specific_area_coeffs[num_effect][13]
+                    + self.temp_last_effect**2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][14]
-                    + b.temp_last_effect**2
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][15]
-                    + temp_steam * specific_area_coeffs[b.number_effects.value][16]
+                    * specific_area_coeffs[num_effect][14]
+                    + self.temp_last_effect**2
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][15]
+                    + temp_steam * specific_area_coeffs[num_effect][16]
                     + temp_steam
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][17]
+                    * specific_area_coeffs[num_effect][17]
                     + temp_steam
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][18]
+                    * specific_area_coeffs[num_effect][18]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][19]
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][19]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][20]
+                    * specific_area_coeffs[num_effect][20]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][21]
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][21]
                     + temp_steam
-                    * b.temp_last_effect
-                    * specific_area_coeffs[b.number_effects.value][22]
+                    * self.temp_last_effect
+                    * specific_area_coeffs[num_effect][22]
                     + temp_steam
-                    * b.temp_last_effect
+                    * self.temp_last_effect
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][23]
+                    * specific_area_coeffs[num_effect][23]
                     + temp_steam
-                    * b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][24]
+                    * self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][24]
                     + temp_steam
-                    * b.temp_last_effect**2
-                    * specific_area_coeffs[b.number_effects.value][25]
-                    + temp_steam**2 * specific_area_coeffs[b.number_effects.value][26]
+                    * self.temp_last_effect**2
+                    * specific_area_coeffs[num_effect][25]
+                    + temp_steam**2 * specific_area_coeffs[num_effect][26]
                     + temp_steam**2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][27]
+                    * specific_area_coeffs[num_effect][27]
                     + temp_steam**2
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][28]
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][28]
                     + temp_steam**2
-                    * b.temp_last_effect
-                    * specific_area_coeffs[b.number_effects.value][29]
-                    + 1 * specific_area_coeffs[b.number_effects.value][30]
-                    + temp_steam**3 * specific_area_coeffs[b.number_effects.value][31]
-                    + b.temp_last_effect**3
-                    * specific_area_coeffs[b.number_effects.value][32]
-                    + b.recovery_vol_phase[0, "Liq"] ** 3
-                    * specific_area_coeffs[b.number_effects.value][33]
+                    * self.temp_last_effect
+                    * specific_area_coeffs[num_effect][29]
+                    + 1 * specific_area_coeffs[num_effect][30]
+                    + temp_steam**3 * specific_area_coeffs[num_effect][31]
+                    + self.temp_last_effect**3
+                    * specific_area_coeffs[num_effect][32]
+                    + self.recovery_vol_phase[0, "Liq"] ** 3
+                    * specific_area_coeffs[num_effect][33]
                     + feed_conc_ppm**3
-                    * specific_area_coeffs[b.number_effects.value][34]
+                    * specific_area_coeffs[num_effect][34]
                 )
 
             else:
                 return (
-                    b.specific_area
-                    == feed_conc_ppm * specific_area_coeffs[b.number_effects.value][0]
+                    feed_conc_ppm * specific_area_coeffs[num_effect][0]
                     + feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][1]
+                    * specific_area_coeffs[num_effect][1]
                     + feed_conc_ppm**3
-                    * specific_area_coeffs[b.number_effects.value][2]
-                    + b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][3]
-                    + b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][2]
+                    + self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][3]
+                    + self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][4]
-                    + b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][4]
+                    + self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][5]
-                    + b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][5]
+                    + self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm**3
-                    * specific_area_coeffs[b.number_effects.value][6]
-                    + b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][7]
-                    + b.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][6]
+                    + self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][7]
+                    + self.recovery_vol_phase[0, "Liq"] ** 2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][8]
-                    + b.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][8]
+                    + self.recovery_vol_phase[0, "Liq"] ** 2
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][9]
-                    + b.recovery_vol_phase[0, "Liq"] ** 3
-                    * specific_area_coeffs[b.number_effects.value][10]
-                    + b.recovery_vol_phase[0, "Liq"] ** 3
+                    * specific_area_coeffs[num_effect][9]
+                    + self.recovery_vol_phase[0, "Liq"] ** 3
+                    * specific_area_coeffs[num_effect][10]
+                    + self.recovery_vol_phase[0, "Liq"] ** 3
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][11]
-                    + b.temp_last_effect
-                    * specific_area_coeffs[b.number_effects.value][12]
-                    + b.temp_last_effect
+                    * specific_area_coeffs[num_effect][11]
+                    + self.temp_last_effect
+                    * specific_area_coeffs[num_effect][12]
+                    + self.temp_last_effect
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][13]
-                    + b.temp_last_effect
+                    * specific_area_coeffs[num_effect][13]
+                    + self.temp_last_effect
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][14]
-                    + b.temp_last_effect
+                    * specific_area_coeffs[num_effect][14]
+                    + self.temp_last_effect
                     * feed_conc_ppm**3
-                    * specific_area_coeffs[b.number_effects.value][15]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][16]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][15]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][16]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][17]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][17]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][18]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][19]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][18]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][19]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][20]
-                    + b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"] ** 3
-                    * specific_area_coeffs[b.number_effects.value][21]
-                    + b.temp_last_effect**2
-                    * specific_area_coeffs[b.number_effects.value][22]
-                    + b.temp_last_effect**2
+                    * specific_area_coeffs[num_effect][20]
+                    + self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"] ** 3
+                    * specific_area_coeffs[num_effect][21]
+                    + self.temp_last_effect**2
+                    * specific_area_coeffs[num_effect][22]
+                    + self.temp_last_effect**2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][23]
-                    + b.temp_last_effect**2
+                    * specific_area_coeffs[num_effect][23]
+                    + self.temp_last_effect**2
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][24]
-                    + b.temp_last_effect**2
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][25]
-                    + b.temp_last_effect**2
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][24]
+                    + self.temp_last_effect**2
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][25]
+                    + self.temp_last_effect**2
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][26]
-                    + b.temp_last_effect**2
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][27]
-                    + b.temp_last_effect**3
-                    * specific_area_coeffs[b.number_effects.value][28]
-                    + b.temp_last_effect**3
+                    * specific_area_coeffs[num_effect][26]
+                    + self.temp_last_effect**2
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][27]
+                    + self.temp_last_effect**3
+                    * specific_area_coeffs[num_effect][28]
+                    + self.temp_last_effect**3
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][29]
-                    + b.temp_last_effect**3
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][30]
-                    + temp_steam * specific_area_coeffs[b.number_effects.value][31]
+                    * specific_area_coeffs[num_effect][29]
+                    + self.temp_last_effect**3
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][30]
+                    + temp_steam * specific_area_coeffs[num_effect][31]
                     + temp_steam
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][32]
+                    * specific_area_coeffs[num_effect][32]
                     + temp_steam
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][33]
+                    * specific_area_coeffs[num_effect][33]
                     + temp_steam
                     * feed_conc_ppm**3
-                    * specific_area_coeffs[b.number_effects.value][34]
+                    * specific_area_coeffs[num_effect][34]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][35]
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][35]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][36]
+                    * specific_area_coeffs[num_effect][36]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][37]
+                    * specific_area_coeffs[num_effect][37]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][38]
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][38]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][39]
+                    * specific_area_coeffs[num_effect][39]
                     + temp_steam
-                    * b.recovery_vol_phase[0, "Liq"] ** 3
-                    * specific_area_coeffs[b.number_effects.value][40]
+                    * self.recovery_vol_phase[0, "Liq"] ** 3
+                    * specific_area_coeffs[num_effect][40]
                     + temp_steam
-                    * b.temp_last_effect
-                    * specific_area_coeffs[b.number_effects.value][41]
+                    * self.temp_last_effect
+                    * specific_area_coeffs[num_effect][41]
                     + temp_steam
-                    * b.temp_last_effect
+                    * self.temp_last_effect
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][42]
+                    * specific_area_coeffs[num_effect][42]
                     + temp_steam
-                    * b.temp_last_effect
+                    * self.temp_last_effect
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][43]
+                    * specific_area_coeffs[num_effect][43]
                     + temp_steam
-                    * b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][44]
+                    * self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][44]
                     + temp_steam
-                    * b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][45]
+                    * specific_area_coeffs[num_effect][45]
                     + temp_steam
-                    * b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][46]
+                    * self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][46]
                     + temp_steam
-                    * b.temp_last_effect**2
-                    * specific_area_coeffs[b.number_effects.value][47]
+                    * self.temp_last_effect**2
+                    * specific_area_coeffs[num_effect][47]
                     + temp_steam
-                    * b.temp_last_effect**2
+                    * self.temp_last_effect**2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][48]
+                    * specific_area_coeffs[num_effect][48]
                     + temp_steam
-                    * b.temp_last_effect**2
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][49]
+                    * self.temp_last_effect**2
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][49]
                     + temp_steam
-                    * b.temp_last_effect**3
-                    * specific_area_coeffs[b.number_effects.value][50]
-                    + temp_steam**2 * specific_area_coeffs[b.number_effects.value][51]
+                    * self.temp_last_effect**3
+                    * specific_area_coeffs[num_effect][50]
+                    + temp_steam**2 * specific_area_coeffs[num_effect][51]
                     + temp_steam**2
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][52]
+                    * specific_area_coeffs[num_effect][52]
                     + temp_steam**2
                     * feed_conc_ppm**2
-                    * specific_area_coeffs[b.number_effects.value][53]
+                    * specific_area_coeffs[num_effect][53]
                     + temp_steam**2
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][54]
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][54]
                     + temp_steam**2
-                    * b.recovery_vol_phase[0, "Liq"]
+                    * self.recovery_vol_phase[0, "Liq"]
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][55]
+                    * specific_area_coeffs[num_effect][55]
                     + temp_steam**2
-                    * b.recovery_vol_phase[0, "Liq"] ** 2
-                    * specific_area_coeffs[b.number_effects.value][56]
+                    * self.recovery_vol_phase[0, "Liq"] ** 2
+                    * specific_area_coeffs[num_effect][56]
                     + temp_steam**2
-                    * b.temp_last_effect
-                    * specific_area_coeffs[b.number_effects.value][57]
+                    * self.temp_last_effect
+                    * specific_area_coeffs[num_effect][57]
                     + temp_steam**2
-                    * b.temp_last_effect
+                    * self.temp_last_effect
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][58]
+                    * specific_area_coeffs[num_effect][58]
                     + temp_steam**2
-                    * b.temp_last_effect
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][59]
+                    * self.temp_last_effect
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][59]
                     + temp_steam**2
-                    * b.temp_last_effect**2
-                    * specific_area_coeffs[b.number_effects.value][60]
-                    + temp_steam**3 * specific_area_coeffs[b.number_effects.value][61]
+                    * self.temp_last_effect**2
+                    * specific_area_coeffs[num_effect][60]
+                    + temp_steam**3 * specific_area_coeffs[num_effect][61]
                     + temp_steam**3
                     * feed_conc_ppm
-                    * specific_area_coeffs[b.number_effects.value][62]
+                    * specific_area_coeffs[num_effect][62]
                     + temp_steam**3
-                    * b.recovery_vol_phase[0, "Liq"]
-                    * specific_area_coeffs[b.number_effects.value][63]
+                    * self.recovery_vol_phase[0, "Liq"]
+                    * specific_area_coeffs[num_effect][63]
                     + temp_steam**3
-                    * b.temp_last_effect
-                    * specific_area_coeffs[b.number_effects.value][64]
-                    + 1 * specific_area_coeffs[b.number_effects.value][65]
-                    + temp_steam**4 * specific_area_coeffs[b.number_effects.value][66]
-                    + b.temp_last_effect**4
-                    * specific_area_coeffs[b.number_effects.value][67]
-                    + b.recovery_vol_phase[0, "Liq"] ** 4
-                    * specific_area_coeffs[b.number_effects.value][68]
+                    * self.temp_last_effect
+                    * specific_area_coeffs[num_effect][64]
+                    + 1 * specific_area_coeffs[num_effect][65]
+                    + temp_steam**4 * specific_area_coeffs[num_effect][66]
+                    + self.temp_last_effect**4
+                    * specific_area_coeffs[num_effect][67]
+                    + self.recovery_vol_phase[0, "Liq"] ** 4
+                    * specific_area_coeffs[num_effect][68]
                     + feed_conc_ppm**4
-                    * specific_area_coeffs[b.number_effects.value][69]
+                    * specific_area_coeffs[num_effect][69]
                 )
+
+        # Surrogate equations were built for 3,6,9,12,14 effects
+        # For intermediate number of effects (4,5,7,8,10,11,13), linear interpolation is adopted
+        @self.Constraint(doc="Gain output ratio surrogate equation")
+        def eq_gain_output_ratio(b):
+            if b.config.number_effects in [3,6,9,12,14]:
+                return (
+                    b.gain_output_ratio
+                    == _get_gain_output_ratio(b.config.number_effects)
+                )
+            else: # number_effects in [4,5,7,8,10,11,13]
+                # find out the closest numbers of effects that have a surrogate equation
+                interp_effects, i = [3,6,9,12,14], 1
+                while interp_effects[i] < b.config.number_effects:
+                    i += 1
+                interp_point1, interp_point2 = interp_effects[i-1], interp_effects[i]
+                
+                # implement linear interpolation using 2 points
+                return (
+                    b.gain_output_ratio
+                    == _get_gain_output_ratio(interp_point1) 
+                    * (interp_point2 - b.config.number_effects)
+                    / (interp_point2 - interp_point1)
+                    +  _get_gain_output_ratio(interp_point2)
+                    * (b.config.number_effects - interp_point1)
+                    / (interp_point2 - interp_point1)
+                )            
+
+        @self.Constraint(doc="Specific area surrogate equation")
+        def eq_specific_area_per_m3_day(b):
+            if b.config.number_effects in [3,6,9,12,14]:
+                return (
+                    b.specific_area_per_m3_day
+                    == _get_specific_area(b.config.number_effects)
+                )
+            else: # number_effects in [4,5,7,8,10,11,13]
+                # find out the closest numbers of effects that have a surrogate equation
+                interp_effects, i = [3,6,9,12,14], 1
+                while interp_effects[i] < b.config.number_effects:
+                    i += 1
+                interp_point1, interp_point2 = interp_effects[i-1], interp_effects[i]
+
+                # implement linear interpolation using 2 points
+                return (
+                    b.specific_area_per_m3_day
+                    == _get_specific_area(interp_point1) 
+                    * (interp_point2 - b.config.number_effects)
+                    / (interp_point2 - interp_point1)
+                    +  _get_specific_area(interp_point2)
+                    * (b.config.number_effects - interp_point1)
+                    / (interp_point2 - interp_point1)
+                )
+
+        @self.Constraint(doc="Convert specific area to m2/kg/s for CAPEX calculation")
+        def eq_specific_area_kg_s(b):
+            return b.specific_area_per_kg_s == pyunits.convert(
+                b.specific_area_per_m3_day / b.feed_props[0].dens_mass_phase["Liq"],
+                to_units=pyunits.m**2 / pyunits.kg * pyunits.s,
+            )
+
 
         # Steam flow rate calculation
         @self.Constraint(doc="Steam flow rate")
@@ -898,6 +972,8 @@ class LTMEDData(UnitModelBlockData):
             solver=solver,
             state_args=state_args,
         )
+        # Check degree of freedom
+        assert degrees_of_freedom(blk) == 0
 
         # Solve unit
         with idaeslog.solver_log(solve_log, idaeslog.DEBUG) as slc:
@@ -928,8 +1004,11 @@ class LTMEDData(UnitModelBlockData):
                 * iscale.get_scaling_factor(self.specific_energy_consumption_thermal),
             )
 
-        if iscale.get_scaling_factor(self.specific_area) is None:
-            iscale.set_scaling_factor(self.specific_area, 0.1)
+        if iscale.get_scaling_factor(self.specific_area_per_m3_day) is None:
+            iscale.set_scaling_factor(self.specific_area_per_m3_day, 0.1)
+
+        if iscale.get_scaling_factor(self.specific_area_per_kg_s) is None:
+            iscale.set_scaling_factor(self.specific_area_per_kg_s, 1e-2)
 
         if iscale.get_scaling_factor(self.gain_output_ratio) is None:
             iscale.set_scaling_factor(self.gain_output_ratio, 0.1)
@@ -945,8 +1024,16 @@ class LTMEDData(UnitModelBlockData):
         sf = iscale.get_scaling_factor(self.distillate_props[0].temperature)
         iscale.constraint_scaling_transform(self.eq_distillate_temp, sf)
 
+        sf = iscale.get_scaling_factor(
+            self.distillate_props[0].flow_mass_phase_comp["Liq", "TDS"]
+        )
+        iscale.constraint_scaling_transform(self.eq_distillate_salinity, sf)
+
         sf = iscale.get_scaling_factor(self.cooling_out_props[0].temperature)
         iscale.constraint_scaling_transform(self.eq_cooling_temp, sf)
+
+        sf = iscale.get_scaling_factor(self.steam_props[0].flow_mass_phase_comp["Liq", "H2O"])
+        iscale.constraint_scaling_transform(self.eq_heating_steam_liquid_mass, sf)
 
         sf = iscale.get_scaling_factor(
             self.cooling_out_props[0].conc_mass_phase_comp["Liq", "TDS"]
@@ -970,8 +1057,11 @@ class LTMEDData(UnitModelBlockData):
         sf = iscale.get_scaling_factor(self.gain_output_ratio)
         iscale.constraint_scaling_transform(self.eq_gain_output_ratio, sf)
 
-        sf = iscale.get_scaling_factor(self.specific_area)
-        iscale.constraint_scaling_transform(self.eq_specific_area, sf)
+        sf = iscale.get_scaling_factor(self.specific_area_per_m3_day)
+        iscale.constraint_scaling_transform(self.eq_specific_area_per_m3_day, sf)
+
+        sf = iscale.get_scaling_factor(self.specific_area_per_kg_s)
+        iscale.constraint_scaling_transform(self.eq_specific_area_kg_s, sf)
 
         sf = iscale.get_scaling_factor(
             self.steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
@@ -1012,6 +1102,37 @@ class LTMEDData(UnitModelBlockData):
             iscale.constraint_scaling_transform(self.eq_feed_to_brine_isobaric[t], sf)
             iscale.constraint_scaling_transform(self.eq_feed_to_cooling_isobaric[t], sf)
 
+    def _get_stream_table_contents(self, time_point=0):
+        return create_stream_table_dataframe(
+            {
+                "Feed Water Inlet": self.feed,
+                "Distillate Outlet": self.distillate,
+                "Brine Outlet": self.brine,
+                "Heating Steam Inlet": self.steam_props,
+            },
+            time_point=time_point,
+        )
+
+    def _get_performance_contents(self, time_point=0):
+        var_dict = {}
+        var_dict["Gained output ratio"] = self.gain_output_ratio
+        var_dict["Thermal power reqruiement (kW)"] = self.thermal_power_requirement
+        var_dict[
+            "Specific thermal energy consumption (kWh/m3)"
+        ] = self.specific_energy_consumption_thermal
+        var_dict["Feed water volumetric flow rate"] = self.feed_props[0].flow_vol_phase[
+            "Liq"
+        ]
+        var_dict["Cooling water volumetric flow rate"] = self.cooling_out_props[
+            0
+        ].flow_vol_phase["Liq"]
+        var_dict["Heating steam mass flow rate"] = self.steam_props[
+            0
+        ].flow_mass_phase_comp["Vap", "H2O"]
+        var_dict["Specific area (m2/m3/day)"] = self.specific_area_per_m3_day
+
+        return {"vars": var_dict}
+
     def _get_gain_output_ratio_coeffs(self):
         return {
             3: [
@@ -1050,7 +1171,7 @@ class LTMEDData(UnitModelBlockData):
             ],
             9: [
                 1.67e-06,
-                5.9507846,
+                5.9507846+1e-3,
                 -3.94e-06,
                 0.012607651,
                 -5.50e-08,

--- a/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
@@ -120,6 +120,15 @@ class MEDTVCData(UnitModelBlockData):
     see property package for documentation.}""",
         ),
     )
+    CONFIG.declare(
+        "number_effects",
+        ConfigBlock(
+            default=12,
+            domain=In([8,9,10,11,12,13,14,15,16]),
+            description="Number of effects of the MED_TVC system",
+            doc="""A ConfigBlock specifying the number of effects, which should be an interger between 8 to 16.""",
+        ),
+    )
 
     def build(self):
         super().build()
@@ -133,14 +142,6 @@ class MEDTVCData(UnitModelBlockData):
         """
         Add system configurations
         """
-        self.number_effects = Param(
-            initialize=12,
-            mutable=True,
-            within=Set(initialize=[8, 10, 12, 14, 16]),
-            units=pyunits.dimensionless,
-            doc="Number of effects",
-        )
-
         self.delta_T_last_effect = Param(
             initialize=10,
             mutable=True,
@@ -404,56 +405,56 @@ class MEDTVCData(UnitModelBlockData):
 
         gain_output_ratio_coeffs = self._get_gain_output_ratio_coeffs()
 
-        @self.Constraint(doc="Gain output ratio  surrogate equation")
+        @self.Constraint(doc="Gain output ratio surrogate equation")
         def eq_gain_output_ratio(b):
             return (
                 b.gain_output_ratio
-                == feed_conc_ppm * gain_output_ratio_coeffs[b.number_effects.value][0]
+                == feed_conc_ppm * gain_output_ratio_coeffs[b.config.number_effects][0]
                 + b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][1]
+                * gain_output_ratio_coeffs[b.config.number_effects][1]
                 + feed_conc_ppm
                 * b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][2]
-                + feed_temperature * gain_output_ratio_coeffs[b.number_effects.value][3]
+                * gain_output_ratio_coeffs[b.config.number_effects][2]
+                + feed_temperature * gain_output_ratio_coeffs[b.config.number_effects][3]
                 + feed_temperature
                 * feed_conc_ppm
-                * gain_output_ratio_coeffs[b.number_effects.value][4]
+                * gain_output_ratio_coeffs[b.config.number_effects][4]
                 + feed_temperature
                 * b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][5]
-                + capacity * gain_output_ratio_coeffs[b.number_effects.value][6]
+                * gain_output_ratio_coeffs[b.config.number_effects][5]
+                + capacity * gain_output_ratio_coeffs[b.config.number_effects][6]
                 + capacity
                 * feed_conc_ppm
-                * gain_output_ratio_coeffs[b.number_effects.value][7]
+                * gain_output_ratio_coeffs[b.config.number_effects][7]
                 + capacity
                 * b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][8]
+                * gain_output_ratio_coeffs[b.config.number_effects][8]
                 + capacity
                 * feed_temperature
-                * gain_output_ratio_coeffs[b.number_effects.value][9]
-                + motive_pressure * gain_output_ratio_coeffs[b.number_effects.value][10]
+                * gain_output_ratio_coeffs[b.config.number_effects][9]
+                + motive_pressure * gain_output_ratio_coeffs[b.config.number_effects][10]
                 + motive_pressure
                 * feed_conc_ppm
-                * gain_output_ratio_coeffs[b.number_effects.value][11]
+                * gain_output_ratio_coeffs[b.config.number_effects][11]
                 + motive_pressure
                 * b.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[b.number_effects.value][12]
+                * gain_output_ratio_coeffs[b.config.number_effects][12]
                 + motive_pressure
                 * feed_temperature
-                * gain_output_ratio_coeffs[b.number_effects.value][13]
+                * gain_output_ratio_coeffs[b.config.number_effects][13]
                 + motive_pressure
                 * capacity
-                * gain_output_ratio_coeffs[b.number_effects.value][14]
-                + 1 * gain_output_ratio_coeffs[b.number_effects.value][15]
+                * gain_output_ratio_coeffs[b.config.number_effects][14]
+                + 1 * gain_output_ratio_coeffs[b.config.number_effects][15]
                 + motive_pressure**2
-                * gain_output_ratio_coeffs[b.number_effects.value][16]
-                + capacity**2 * gain_output_ratio_coeffs[b.number_effects.value][17]
+                * gain_output_ratio_coeffs[b.config.number_effects][16]
+                + capacity**2 * gain_output_ratio_coeffs[b.config.number_effects][17]
                 + feed_temperature**2
-                * gain_output_ratio_coeffs[b.number_effects.value][18]
+                * gain_output_ratio_coeffs[b.config.number_effects][18]
                 + b.recovery_vol_phase[0, "Liq"] ** 2
-                * gain_output_ratio_coeffs[b.number_effects.value][19]
+                * gain_output_ratio_coeffs[b.config.number_effects][19]
                 + feed_conc_ppm**2
-                * gain_output_ratio_coeffs[b.number_effects.value][20]
+                * gain_output_ratio_coeffs[b.config.number_effects][20]
             )
 
         specific_area_coeffs = self._get_specific_area_coeffs()
@@ -462,51 +463,51 @@ class MEDTVCData(UnitModelBlockData):
         def eq_specific_area(b):
             return (
                 b.specific_area_per_m3_day
-                == feed_conc_ppm * specific_area_coeffs[b.number_effects.value][0]
+                == feed_conc_ppm * specific_area_coeffs[b.config.number_effects][0]
                 + b.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[b.number_effects.value][1]
+                * specific_area_coeffs[b.config.number_effects][1]
                 + feed_conc_ppm
                 * b.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[b.number_effects.value][2]
-                + feed_temperature * specific_area_coeffs[b.number_effects.value][3]
+                * specific_area_coeffs[b.config.number_effects][2]
+                + feed_temperature * specific_area_coeffs[b.config.number_effects][3]
                 + feed_temperature
                 * feed_conc_ppm
-                * specific_area_coeffs[b.number_effects.value][4]
+                * specific_area_coeffs[b.config.number_effects][4]
                 + feed_temperature
                 * b.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[b.number_effects.value][5]
-                + capacity * specific_area_coeffs[b.number_effects.value][6]
+                * specific_area_coeffs[b.config.number_effects][5]
+                + capacity * specific_area_coeffs[b.config.number_effects][6]
                 + capacity
                 * feed_conc_ppm
-                * specific_area_coeffs[b.number_effects.value][7]
+                * specific_area_coeffs[b.config.number_effects][7]
                 + capacity
                 * b.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[b.number_effects.value][8]
+                * specific_area_coeffs[b.config.number_effects][8]
                 + capacity
                 * feed_temperature
-                * specific_area_coeffs[b.number_effects.value][9]
-                + motive_pressure * specific_area_coeffs[b.number_effects.value][10]
+                * specific_area_coeffs[b.config.number_effects][9]
+                + motive_pressure * specific_area_coeffs[b.config.number_effects][10]
                 + motive_pressure
                 * feed_conc_ppm
-                * specific_area_coeffs[b.number_effects.value][11]
+                * specific_area_coeffs[b.config.number_effects][11]
                 + motive_pressure
                 * b.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[b.number_effects.value][12]
+                * specific_area_coeffs[b.config.number_effects][12]
                 + motive_pressure
                 * feed_temperature
-                * specific_area_coeffs[b.number_effects.value][13]
+                * specific_area_coeffs[b.config.number_effects][13]
                 + motive_pressure
                 * capacity
-                * specific_area_coeffs[b.number_effects.value][14]
-                + 1 * specific_area_coeffs[b.number_effects.value][15]
+                * specific_area_coeffs[b.config.number_effects][14]
+                + 1 * specific_area_coeffs[b.config.number_effects][15]
                 + motive_pressure**2
-                * specific_area_coeffs[b.number_effects.value][16]
-                + capacity**2 * specific_area_coeffs[b.number_effects.value][17]
+                * specific_area_coeffs[b.config.number_effects][16]
+                + capacity**2 * specific_area_coeffs[b.config.number_effects][17]
                 + feed_temperature**2
-                * specific_area_coeffs[b.number_effects.value][18]
+                * specific_area_coeffs[b.config.number_effects][18]
                 + b.recovery_vol_phase[0, "Liq"] ** 2
-                * specific_area_coeffs[b.number_effects.value][19]
-                + feed_conc_ppm**2 * specific_area_coeffs[b.number_effects.value][20]
+                * specific_area_coeffs[b.config.number_effects][19]
+                + feed_conc_ppm**2 * specific_area_coeffs[b.config.number_effects][20]
             )
 
         @self.Constraint(doc="Convert specific area to m2/kg/s for CAPEX calculation")
@@ -525,56 +526,56 @@ class MEDTVCData(UnitModelBlockData):
             return (
                 b.heating_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
                 == feed_conc_ppm
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][0]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][0]
                 + b.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][1]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][1]
                 + feed_conc_ppm
                 * b.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][2]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][2]
                 + feed_temperature
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][3]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][3]
                 + feed_temperature
                 * feed_conc_ppm
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][4]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][4]
                 + feed_temperature
                 * b.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][5]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][5]
                 + capacity
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][6]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][6]
                 + capacity
                 * feed_conc_ppm
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][7]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][7]
                 + capacity
                 * b.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][8]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][8]
                 + capacity
                 * feed_temperature
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][9]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][9]
                 + motive_pressure
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][10]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][10]
                 + motive_pressure
                 * feed_conc_ppm
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][11]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][11]
                 + motive_pressure
                 * b.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][12]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][12]
                 + motive_pressure
                 * feed_temperature
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][13]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][13]
                 + motive_pressure
                 * capacity
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][14]
-                + 1 * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][15]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][14]
+                + 1 * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][15]
                 + motive_pressure**2
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][16]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][16]
                 + capacity**2
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][17]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][17]
                 + feed_temperature**2
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][18]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][18]
                 + b.recovery_vol_phase[0, "Liq"] ** 2
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][19]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][19]
                 + feed_conc_ppm**2
-                * heating_steam_mass_flow_rate_coeffs[b.number_effects.value][20]
+                * heating_steam_mass_flow_rate_coeffs[b.config.number_effects][20]
             )
 
         motive_steam_mass_flow_rate_coeffs = (
@@ -586,56 +587,56 @@ class MEDTVCData(UnitModelBlockData):
             return (
                 b.motive_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
                 == feed_conc_ppm
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][0]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][0]
                 + b.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][1]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][1]
                 + feed_conc_ppm
                 * b.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][2]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][2]
                 + feed_temperature
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][3]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][3]
                 + feed_temperature
                 * feed_conc_ppm
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][4]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][4]
                 + feed_temperature
                 * b.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][5]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][5]
                 + capacity
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][6]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][6]
                 + capacity
                 * feed_conc_ppm
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][7]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][7]
                 + capacity
                 * b.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][8]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][8]
                 + capacity
                 * feed_temperature
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][9]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][9]
                 + motive_pressure
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][10]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][10]
                 + motive_pressure
                 * feed_conc_ppm
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][11]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][11]
                 + motive_pressure
                 * b.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][12]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][12]
                 + motive_pressure
                 * feed_temperature
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][13]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][13]
                 + motive_pressure
                 * capacity
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][14]
-                + 1 * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][15]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][14]
+                + 1 * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][15]
                 + motive_pressure**2
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][16]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][16]
                 + capacity**2
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][17]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][17]
                 + feed_temperature**2
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][18]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][18]
                 + b.recovery_vol_phase[0, "Liq"] ** 2
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][19]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][19]
                 + feed_conc_ppm**2
-                * motive_steam_mass_flow_rate_coeffs[b.number_effects.value][20]
+                * motive_steam_mass_flow_rate_coeffs[b.config.number_effects][20]
             )
 
         # Energy consumption

--- a/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
@@ -134,6 +134,10 @@ class MEDTVCData(UnitModelBlockData):
             self.config.property_package_liquid.get_metadata().get_derived_units
         )
 
+        # Check if the number of effects is valid
+        if self.config.number_effects not in [i for i in range(8, 17)]:
+            raise ConfigurationError("The number of effects should be an integer between 8 to 16")
+
         """
         Add system configurations
         """
@@ -382,257 +386,65 @@ class MEDTVCData(UnitModelBlockData):
             doc="Feed and cooling water volume flow rate (m3/h)",
         )
 
-        feed_conc_ppm = pyunits.convert(
+        self.feed_conc_ppm = pyunits.convert(
             self.feed_props[0].conc_mass_phase_comp["Liq", "TDS"],
             to_units=pyunits.mg / pyunits.L,
         )
 
-        capacity = pyunits.convert(
+        self.capacity = pyunits.convert(
             self.feed_props[0].flow_vol_phase["Liq"]
             * self.recovery_vol_phase[0, "Liq"],
             to_units=pyunits.m**3 / pyunits.day,
         )
 
-        feed_temperature = self.feed_props[0].temperature - 273.15
-
-        motive_pressure = pyunits.convert(
+        # Set alias for use in the surrogate equations
+        self.feed_temperature = self.feed_props[0].temperature - 273.15
+        self.motive_pressure = pyunits.convert(
             self.motive_steam_props[0].pressure, to_units=pyunits.bar
         )
 
-        gain_output_ratio_coeffs = self._get_gain_output_ratio_coeffs()
-
-        # Gain output ratio surrogate equation, as a function of the number of effect
-        def _get_gain_output_ratio(num_effect):
-            return (
-                feed_conc_ppm * gain_output_ratio_coeffs[num_effect][0]
-                + self.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[num_effect][1]
-                + feed_conc_ppm
-                * self.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[num_effect][2]
-                + feed_temperature * gain_output_ratio_coeffs[num_effect][3]
-                + feed_temperature
-                * feed_conc_ppm
-                * gain_output_ratio_coeffs[num_effect][4]
-                + feed_temperature
-                * self.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[num_effect][5]
-                + capacity * gain_output_ratio_coeffs[num_effect][6]
-                + capacity * feed_conc_ppm * gain_output_ratio_coeffs[num_effect][7]
-                + capacity
-                * self.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[num_effect][8]
-                + capacity * feed_temperature * gain_output_ratio_coeffs[num_effect][9]
-                + motive_pressure * gain_output_ratio_coeffs[num_effect][10]
-                + motive_pressure
-                * feed_conc_ppm
-                * gain_output_ratio_coeffs[num_effect][11]
-                + motive_pressure
-                * self.recovery_vol_phase[0, "Liq"]
-                * gain_output_ratio_coeffs[num_effect][12]
-                + motive_pressure
-                * feed_temperature
-                * gain_output_ratio_coeffs[num_effect][13]
-                + motive_pressure * capacity * gain_output_ratio_coeffs[num_effect][14]
-                + 1 * gain_output_ratio_coeffs[num_effect][15]
-                + motive_pressure**2 * gain_output_ratio_coeffs[num_effect][16]
-                + capacity**2 * gain_output_ratio_coeffs[num_effect][17]
-                + feed_temperature**2 * gain_output_ratio_coeffs[num_effect][18]
-                + self.recovery_vol_phase[0, "Liq"] ** 2
-                * gain_output_ratio_coeffs[num_effect][19]
-                + feed_conc_ppm**2 * gain_output_ratio_coeffs[num_effect][20]
-            )
-
-        specific_area_coeffs = self._get_specific_area_coeffs()
-
-        # Specific area surrogate equation, as a function of the number of effect
-        def _get_specific_area(num_effect):
-            return (
-                feed_conc_ppm * specific_area_coeffs[num_effect][0]
-                + self.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[num_effect][1]
-                + feed_conc_ppm
-                * self.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[num_effect][2]
-                + feed_temperature * specific_area_coeffs[num_effect][3]
-                + feed_temperature * feed_conc_ppm * specific_area_coeffs[num_effect][4]
-                + feed_temperature
-                * self.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[num_effect][5]
-                + capacity * specific_area_coeffs[num_effect][6]
-                + capacity * feed_conc_ppm * specific_area_coeffs[num_effect][7]
-                + capacity
-                * self.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[num_effect][8]
-                + capacity * feed_temperature * specific_area_coeffs[num_effect][9]
-                + motive_pressure * specific_area_coeffs[num_effect][10]
-                + motive_pressure * feed_conc_ppm * specific_area_coeffs[num_effect][11]
-                + motive_pressure
-                * self.recovery_vol_phase[0, "Liq"]
-                * specific_area_coeffs[num_effect][12]
-                + motive_pressure
-                * feed_temperature
-                * specific_area_coeffs[num_effect][13]
-                + motive_pressure * capacity * specific_area_coeffs[num_effect][14]
-                + 1 * specific_area_coeffs[num_effect][15]
-                + motive_pressure**2 * specific_area_coeffs[num_effect][16]
-                + capacity**2 * specific_area_coeffs[num_effect][17]
-                + feed_temperature**2 * specific_area_coeffs[num_effect][18]
-                + self.recovery_vol_phase[0, "Liq"] ** 2
-                * specific_area_coeffs[num_effect][19]
-                + feed_conc_ppm**2 * specific_area_coeffs[num_effect][20]
-            )
-
-        heating_steam_mass_flow_rate_coeffs = (
+        # Get coefficients for surrogate equations
+        self.gain_output_ratio_coeffs = self._get_gain_output_ratio_coeffs()
+        self.specific_area_coeffs = self._get_specific_area_coeffs()
+        self.heating_steam_mass_flow_rate_coeffs = (
             self._get_heating_steam_mass_flow_rate_coeffs()
         )
-
-        # Heating steam mass flow rate surrogate equation, as a function of the number of effect
-        def _get_heating_steam_mass_flow_rate(num_effect):
-            return (
-                feed_conc_ppm * heating_steam_mass_flow_rate_coeffs[num_effect][0]
-                + self.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[num_effect][1]
-                + feed_conc_ppm
-                * self.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[num_effect][2]
-                + feed_temperature * heating_steam_mass_flow_rate_coeffs[num_effect][3]
-                + feed_temperature
-                * feed_conc_ppm
-                * heating_steam_mass_flow_rate_coeffs[num_effect][4]
-                + feed_temperature
-                * self.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[num_effect][5]
-                + capacity * heating_steam_mass_flow_rate_coeffs[num_effect][6]
-                + capacity
-                * feed_conc_ppm
-                * heating_steam_mass_flow_rate_coeffs[num_effect][7]
-                + capacity
-                * self.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[num_effect][8]
-                + capacity
-                * feed_temperature
-                * heating_steam_mass_flow_rate_coeffs[num_effect][9]
-                + motive_pressure * heating_steam_mass_flow_rate_coeffs[num_effect][10]
-                + motive_pressure
-                * feed_conc_ppm
-                * heating_steam_mass_flow_rate_coeffs[num_effect][11]
-                + motive_pressure
-                * self.recovery_vol_phase[0, "Liq"]
-                * heating_steam_mass_flow_rate_coeffs[num_effect][12]
-                + motive_pressure
-                * feed_temperature
-                * heating_steam_mass_flow_rate_coeffs[num_effect][13]
-                + motive_pressure
-                * capacity
-                * heating_steam_mass_flow_rate_coeffs[num_effect][14]
-                + 1 * heating_steam_mass_flow_rate_coeffs[num_effect][15]
-                + motive_pressure**2
-                * heating_steam_mass_flow_rate_coeffs[num_effect][16]
-                + capacity**2 * heating_steam_mass_flow_rate_coeffs[num_effect][17]
-                + feed_temperature**2
-                * heating_steam_mass_flow_rate_coeffs[num_effect][18]
-                + self.recovery_vol_phase[0, "Liq"] ** 2
-                * heating_steam_mass_flow_rate_coeffs[num_effect][19]
-                + feed_conc_ppm**2
-                * heating_steam_mass_flow_rate_coeffs[num_effect][20]
-            )
-
-        motive_steam_mass_flow_rate_coeffs = (
+        self.motive_steam_mass_flow_rate_coeffs = (
             self._get_motive_steam_mass_flow_rate_coeffs()
         )
-
-        # Motive steam mass flow rate surrogate equation, as a function of the number of effect
-        def _get_motive_steam_mass_flow_rate(num_effect):
-            return (
-                feed_conc_ppm * motive_steam_mass_flow_rate_coeffs[num_effect][0]
-                + self.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[num_effect][1]
-                + feed_conc_ppm
-                * self.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[num_effect][2]
-                + feed_temperature * motive_steam_mass_flow_rate_coeffs[num_effect][3]
-                + feed_temperature
-                * feed_conc_ppm
-                * motive_steam_mass_flow_rate_coeffs[num_effect][4]
-                + feed_temperature
-                * self.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[num_effect][5]
-                + capacity * motive_steam_mass_flow_rate_coeffs[num_effect][6]
-                + capacity
-                * feed_conc_ppm
-                * motive_steam_mass_flow_rate_coeffs[num_effect][7]
-                + capacity
-                * self.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[num_effect][8]
-                + capacity
-                * feed_temperature
-                * motive_steam_mass_flow_rate_coeffs[num_effect][9]
-                + motive_pressure * motive_steam_mass_flow_rate_coeffs[num_effect][10]
-                + motive_pressure
-                * feed_conc_ppm
-                * motive_steam_mass_flow_rate_coeffs[num_effect][11]
-                + motive_pressure
-                * self.recovery_vol_phase[0, "Liq"]
-                * motive_steam_mass_flow_rate_coeffs[num_effect][12]
-                + motive_pressure
-                * feed_temperature
-                * motive_steam_mass_flow_rate_coeffs[num_effect][13]
-                + motive_pressure
-                * capacity
-                * motive_steam_mass_flow_rate_coeffs[num_effect][14]
-                + 1 * motive_steam_mass_flow_rate_coeffs[num_effect][15]
-                + motive_pressure**2
-                * motive_steam_mass_flow_rate_coeffs[num_effect][16]
-                + capacity**2 * motive_steam_mass_flow_rate_coeffs[num_effect][17]
-                + feed_temperature**2
-                * motive_steam_mass_flow_rate_coeffs[num_effect][18]
-                + self.recovery_vol_phase[0, "Liq"] ** 2
-                * motive_steam_mass_flow_rate_coeffs[num_effect][19]
-                + feed_conc_ppm**2
-                * motive_steam_mass_flow_rate_coeffs[num_effect][20]
-            )
 
         # Surrogate equations were built for 8,10,12,14,16 effects
         # For intermediate number of effects (9,11,13,15), linear interpolation is adopted
         @self.Constraint(doc="Gain output ratio surrogate equation")
         def eq_gain_output_ratio(b):
             if b.config.number_effects in [8, 10, 12, 14, 16]:
-                return b.gain_output_ratio == _get_gain_output_ratio(
+                return b.gain_output_ratio == self._get_gain_output_ratio(
                     b.config.number_effects
                 )
-            elif b.config.number_effects in [9, 11, 13, 15]:
+            else: # b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.gain_output_ratio
                     == (
-                        _get_gain_output_ratio(b.config.number_effects - 1)
-                        + _get_gain_output_ratio(b.config.number_effects + 1)
+                        self._get_gain_output_ratio(b.config.number_effects - 1)
+                        + self._get_gain_output_ratio(b.config.number_effects + 1)
                     )
                     / 2
-                )
-            else:
-                raise Exception(
-                    "Only integers between 8 to 16 are allowed for the number of effects"
                 )
 
         @self.Constraint(doc="specific area surrogate equation")
         def eq_specific_area(b):
             if b.config.number_effects in [8, 10, 12, 14, 16]:
-                return b.specific_area_per_m3_day == _get_specific_area(
+                return b.specific_area_per_m3_day == self._get_specific_area(
                     b.config.number_effects
                 )
-            elif b.config.number_effects in [9, 11, 13, 15]:
+            else: # b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.specific_area_per_m3_day
                     == (
-                        _get_specific_area(b.config.number_effects - 1)
-                        + _get_specific_area(b.config.number_effects + 1)
+                        self._get_specific_area(b.config.number_effects - 1)
+                        + self._get_specific_area(b.config.number_effects + 1)
                     )
                     / 2
-                )
-            else:
-                raise Exception(
-                    "Only integers between 8 to 16 are allowed for the number of effects"
                 )
 
         @self.Constraint(doc="Convert specific area to m2/kg/s for CAPEX calculation")
@@ -647,19 +459,15 @@ class MEDTVCData(UnitModelBlockData):
             if b.config.number_effects in [8, 10, 12, 14, 16]:
                 return b.heating_steam_props[0].flow_mass_phase_comp[
                     "Vap", "H2O"
-                ] == _get_heating_steam_mass_flow_rate(b.config.number_effects)
-            elif b.config.number_effects in [9, 11, 13, 15]:
+                ] == self._get_heating_steam_mass_flow_rate(b.config.number_effects)
+            else: # b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.heating_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
                     == (
-                        _get_heating_steam_mass_flow_rate(b.config.number_effects - 1)
-                        + _get_heating_steam_mass_flow_rate(b.config.number_effects + 1)
+                        self._get_heating_steam_mass_flow_rate(b.config.number_effects - 1)
+                        + self._get_heating_steam_mass_flow_rate(b.config.number_effects + 1)
                     )
                     / 2
-                )
-            else:
-                raise Exception(
-                    "Only integers between 8 to 16 are allowed for the number of effects"
                 )
 
         @self.Constraint(doc="motive steam mass flow rate surrogate equation")
@@ -667,19 +475,15 @@ class MEDTVCData(UnitModelBlockData):
             if b.config.number_effects in [8, 10, 12, 14, 16]:
                 return b.motive_steam_props[0].flow_mass_phase_comp[
                     "Vap", "H2O"
-                ] == _get_motive_steam_mass_flow_rate(b.config.number_effects)
-            elif b.config.number_effects in [9, 11, 13, 15]:
+                ] == self._get_motive_steam_mass_flow_rate(b.config.number_effects)
+            else: # b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.motive_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
                     == (
-                        _get_motive_steam_mass_flow_rate(b.config.number_effects - 1)
-                        + _get_motive_steam_mass_flow_rate(b.config.number_effects + 1)
+                        self._get_motive_steam_mass_flow_rate(b.config.number_effects - 1)
+                        + self._get_motive_steam_mass_flow_rate(b.config.number_effects + 1)
                     )
                     / 2
-                )
-            else:
-                raise Exception(
-                    "Only integers between 8 to 16 are allowed for the number of effects"
                 )
 
         # Energy consumption
@@ -1519,3 +1323,185 @@ class MEDTVCData(UnitModelBlockData):
                 8.59e-12,
             ],
         }
+
+    # Gain output ratio surrogate equation, as a function of the number of effect
+    def _get_gain_output_ratio(self, num_effect):
+        return (
+            self.feed_conc_ppm * self.gain_output_ratio_coeffs[num_effect][0]
+            + self.recovery_vol_phase[0, "Liq"]
+            * self.gain_output_ratio_coeffs[num_effect][1]
+            + self.feed_conc_ppm
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.gain_output_ratio_coeffs[num_effect][2]
+            + self.feed_temperature * self.gain_output_ratio_coeffs[num_effect][3]
+            + self.feed_temperature
+            * self.feed_conc_ppm
+            * self.gain_output_ratio_coeffs[num_effect][4]
+            + self.feed_temperature
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.gain_output_ratio_coeffs[num_effect][5]
+            + self.capacity * self.gain_output_ratio_coeffs[num_effect][6]
+            + self.capacity * self.feed_conc_ppm * self.gain_output_ratio_coeffs[num_effect][7]
+            + self.capacity
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.gain_output_ratio_coeffs[num_effect][8]
+            + self.capacity * self.feed_temperature * self.gain_output_ratio_coeffs[num_effect][9]
+            + self.motive_pressure * self.gain_output_ratio_coeffs[num_effect][10]
+            + self.motive_pressure
+            * self.feed_conc_ppm
+            * self.gain_output_ratio_coeffs[num_effect][11]
+            + self.motive_pressure
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.gain_output_ratio_coeffs[num_effect][12]
+            + self.motive_pressure
+            * self.feed_temperature
+            * self.gain_output_ratio_coeffs[num_effect][13]
+            + self.motive_pressure * self.capacity * self.gain_output_ratio_coeffs[num_effect][14]
+            + 1 * self.gain_output_ratio_coeffs[num_effect][15]
+            + self.motive_pressure**2 * self.gain_output_ratio_coeffs[num_effect][16]
+            + self.capacity**2 * self.gain_output_ratio_coeffs[num_effect][17]
+            + self.feed_temperature**2 * self.gain_output_ratio_coeffs[num_effect][18]
+            + self.recovery_vol_phase[0, "Liq"] ** 2
+            * self.gain_output_ratio_coeffs[num_effect][19]
+            + self.feed_conc_ppm**2 * self.gain_output_ratio_coeffs[num_effect][20]
+        )
+
+    # Specific area surrogate equation, as a function of the number of effect
+    def _get_specific_area(self, num_effect):
+        return (
+            self.feed_conc_ppm * self.specific_area_coeffs[num_effect][0]
+            + self.recovery_vol_phase[0, "Liq"]
+            * self.specific_area_coeffs[num_effect][1]
+            + self.feed_conc_ppm
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.specific_area_coeffs[num_effect][2]
+            + self.feed_temperature * self.specific_area_coeffs[num_effect][3]
+            + self.feed_temperature * self.feed_conc_ppm * self.specific_area_coeffs[num_effect][4]
+            + self.feed_temperature
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.specific_area_coeffs[num_effect][5]
+            + self.capacity * self.specific_area_coeffs[num_effect][6]
+            + self.capacity * self.feed_conc_ppm * self.specific_area_coeffs[num_effect][7]
+            + self.capacity
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.specific_area_coeffs[num_effect][8]
+            + self.capacity * self.feed_temperature * self.specific_area_coeffs[num_effect][9]
+            + self.motive_pressure * self.specific_area_coeffs[num_effect][10]
+            + self.motive_pressure * self.feed_conc_ppm * self.specific_area_coeffs[num_effect][11]
+            + self.motive_pressure
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.specific_area_coeffs[num_effect][12]
+            + self.motive_pressure
+            * self.feed_temperature
+            * self.specific_area_coeffs[num_effect][13]
+            + self.motive_pressure * self.capacity * self.specific_area_coeffs[num_effect][14]
+            + 1 * self.specific_area_coeffs[num_effect][15]
+            + self.motive_pressure**2 * self.specific_area_coeffs[num_effect][16]
+            + self.capacity**2 * self.specific_area_coeffs[num_effect][17]
+            + self.feed_temperature**2 * self.specific_area_coeffs[num_effect][18]
+            + self.recovery_vol_phase[0, "Liq"] ** 2
+            * self.specific_area_coeffs[num_effect][19]
+            + self.feed_conc_ppm**2 * self.specific_area_coeffs[num_effect][20]
+        )
+
+    # Heating steam mass flow rate surrogate equation, as a function of the number of effect
+    def _get_heating_steam_mass_flow_rate(self, num_effect):
+        return (
+            self.feed_conc_ppm * self.heating_steam_mass_flow_rate_coeffs[num_effect][0]
+            + self.recovery_vol_phase[0, "Liq"]
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][1]
+            + self.feed_conc_ppm
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][2]
+            + self.feed_temperature * self.heating_steam_mass_flow_rate_coeffs[num_effect][3]
+            + self.feed_temperature
+            * self.feed_conc_ppm
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][4]
+            + self.feed_temperature
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][5]
+            + self.capacity * self.heating_steam_mass_flow_rate_coeffs[num_effect][6]
+            + self.capacity
+            * self.feed_conc_ppm
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][7]
+            + self.capacity
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][8]
+            + self.capacity
+            * self.feed_temperature
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][9]
+            + self.motive_pressure * self.heating_steam_mass_flow_rate_coeffs[num_effect][10]
+            + self.motive_pressure
+            * self.feed_conc_ppm
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][11]
+            + self.motive_pressure
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][12]
+            + self.motive_pressure
+            * self.feed_temperature
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][13]
+            + self.motive_pressure
+            * self.capacity
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][14]
+            + 1 * self.heating_steam_mass_flow_rate_coeffs[num_effect][15]
+            + self.motive_pressure**2
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][16]
+            + self.capacity**2 * self.heating_steam_mass_flow_rate_coeffs[num_effect][17]
+            + self.feed_temperature**2
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][18]
+            + self.recovery_vol_phase[0, "Liq"] ** 2
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][19]
+            + self.feed_conc_ppm**2
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][20]
+        )
+
+    # Motive steam mass flow rate surrogate equation, as a function of the number of effect
+    def _get_motive_steam_mass_flow_rate(self, num_effect):
+        return (
+            self.feed_conc_ppm * self.motive_steam_mass_flow_rate_coeffs[num_effect][0]
+            + self.recovery_vol_phase[0, "Liq"]
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][1]
+            + self.feed_conc_ppm
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][2]
+            + self.feed_temperature * self.motive_steam_mass_flow_rate_coeffs[num_effect][3]
+            + self.feed_temperature
+            * self.feed_conc_ppm
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][4]
+            + self.feed_temperature
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][5]
+            + self.capacity * self.motive_steam_mass_flow_rate_coeffs[num_effect][6]
+            + self.capacity
+            * self.feed_conc_ppm
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][7]
+            + self.capacity
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][8]
+            + self.capacity
+            * self.feed_temperature
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][9]
+            + self.motive_pressure * self.motive_steam_mass_flow_rate_coeffs[num_effect][10]
+            + self.motive_pressure
+            * self.feed_conc_ppm
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][11]
+            + self.motive_pressure
+            * self.recovery_vol_phase[0, "Liq"]
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][12]
+            + self.motive_pressure
+            * self.feed_temperature
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][13]
+            + self.motive_pressure
+            * self.capacity
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][14]
+            + 1 * self.motive_steam_mass_flow_rate_coeffs[num_effect][15]
+            + self.motive_pressure**2
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][16]
+            + self.capacity**2 * self.motive_steam_mass_flow_rate_coeffs[num_effect][17]
+            + self.feed_temperature**2
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][18]
+            + self.recovery_vol_phase[0, "Liq"] ** 2
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][19]
+            + self.feed_conc_ppm**2
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][20]
+        )

--- a/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
@@ -121,7 +121,7 @@ class MEDTVCData(UnitModelBlockData):
             default=12,
             domain=In(range(8, 17)),
             description="Number of effects of the MED_TVC system",
-            doc="""A ConfigBlock specifying the number of effects, which should be an interger between 8 to 16.""",
+            doc="""A ConfigBlock specifying the number of effects, which should be an integer between 8 to 16.""",
         ),
     )
 
@@ -200,9 +200,7 @@ class MEDTVCData(UnitModelBlockData):
             )
 
         # salinity in distillate is zero
-        @self.Constraint(doc="distillate salinity")
-        def eq_distillate_salinity(b):
-            return b.distillate_props[0].flow_mass_phase_comp["Liq", "TDS"] == 0
+        self.distillate_props[0].flow_mass_phase_comp["Liq", "TDS"].fix(0)
 
         """
         Add block for brine
@@ -603,7 +601,7 @@ class MEDTVCData(UnitModelBlockData):
                 return b.gain_output_ratio == _get_gain_output_ratio(
                     b.config.number_effects
                 )
-            else:  # number_effects in [9,11,13,15]
+            elif b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.gain_output_ratio
                     == (
@@ -612,6 +610,10 @@ class MEDTVCData(UnitModelBlockData):
                     )
                     / 2
                 )
+            else:
+                raise Exception(
+                    "Only integers between 8 to 16 are allowed for the number of effects"
+                )
 
         @self.Constraint(doc="specific area surrogate equation")
         def eq_specific_area(b):
@@ -619,7 +621,7 @@ class MEDTVCData(UnitModelBlockData):
                 return b.specific_area_per_m3_day == _get_specific_area(
                     b.config.number_effects
                 )
-            else:  # number_effects in [9,11,13,15]
+            elif b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.specific_area_per_m3_day
                     == (
@@ -627,6 +629,10 @@ class MEDTVCData(UnitModelBlockData):
                         + _get_specific_area(b.config.number_effects + 1)
                     )
                     / 2
+                )
+            else:
+                raise Exception(
+                    "Only integers between 8 to 16 are allowed for the number of effects"
                 )
 
         @self.Constraint(doc="Convert specific area to m2/kg/s for CAPEX calculation")
@@ -642,7 +648,7 @@ class MEDTVCData(UnitModelBlockData):
                 return b.heating_steam_props[0].flow_mass_phase_comp[
                     "Vap", "H2O"
                 ] == _get_heating_steam_mass_flow_rate(b.config.number_effects)
-            else:  # number_effects in [9,11,13,15]
+            elif b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.heating_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
                     == (
@@ -651,6 +657,10 @@ class MEDTVCData(UnitModelBlockData):
                     )
                     / 2
                 )
+            else:
+                raise Exception(
+                    "Only integers between 8 to 16 are allowed for the number of effects"
+                )
 
         @self.Constraint(doc="motive steam mass flow rate surrogate equation")
         def eq_motive_steam_mass_flow_rate(b):
@@ -658,7 +668,7 @@ class MEDTVCData(UnitModelBlockData):
                 return b.motive_steam_props[0].flow_mass_phase_comp[
                     "Vap", "H2O"
                 ] == _get_motive_steam_mass_flow_rate(b.config.number_effects)
-            else:  # number_effects in [9,11,13,15]
+            elif b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.motive_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
                     == (
@@ -666,6 +676,10 @@ class MEDTVCData(UnitModelBlockData):
                         + _get_motive_steam_mass_flow_rate(b.config.number_effects + 1)
                     )
                     / 2
+                )
+            else:
+                raise Exception(
+                    "Only integers between 8 to 16 are allowed for the number of effects"
                 )
 
         # Energy consumption
@@ -912,11 +926,6 @@ class MEDTVCData(UnitModelBlockData):
         # Transforming constraints
         sf = iscale.get_scaling_factor(self.distillate_props[0].temperature)
         iscale.constraint_scaling_transform(self.eq_distillate_temp, sf)
-
-        sf = iscale.get_scaling_factor(
-            self.distillate_props[0].flow_mass_phase_comp["Liq", "TDS"]
-        )
-        iscale.constraint_scaling_transform(self.eq_distillate_salinity, sf)
 
         sf = iscale.get_scaling_factor(
             self.heating_steam_props[0].flow_mass_phase_comp["Liq", "H2O"]

--- a/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
@@ -48,6 +48,7 @@ from watertap.property_models.water_prop_pack import WaterParameterBlock
 _log = idaeslog.getLogger(__name__)
 __author__ = "Zhuoran Zhang"
 
+
 @declare_process_block_class("MEDTVCSurrogate")
 class MEDTVCData(UnitModelBlockData):
     """
@@ -118,7 +119,7 @@ class MEDTVCData(UnitModelBlockData):
         "number_effects",
         ConfigValue(
             default=12,
-            domain=In(range(8,17)),
+            domain=In(range(8, 17)),
             description="Number of effects of the MED_TVC system",
             doc="""A ConfigBlock specifying the number of effects, which should be an interger between 8 to 16.""",
         ),
@@ -419,15 +420,11 @@ class MEDTVCData(UnitModelBlockData):
                 * self.recovery_vol_phase[0, "Liq"]
                 * gain_output_ratio_coeffs[num_effect][5]
                 + capacity * gain_output_ratio_coeffs[num_effect][6]
-                + capacity
-                * feed_conc_ppm
-                * gain_output_ratio_coeffs[num_effect][7]
+                + capacity * feed_conc_ppm * gain_output_ratio_coeffs[num_effect][7]
                 + capacity
                 * self.recovery_vol_phase[0, "Liq"]
                 * gain_output_ratio_coeffs[num_effect][8]
-                + capacity
-                * feed_temperature
-                * gain_output_ratio_coeffs[num_effect][9]
+                + capacity * feed_temperature * gain_output_ratio_coeffs[num_effect][9]
                 + motive_pressure * gain_output_ratio_coeffs[num_effect][10]
                 + motive_pressure
                 * feed_conc_ppm
@@ -438,26 +435,21 @@ class MEDTVCData(UnitModelBlockData):
                 + motive_pressure
                 * feed_temperature
                 * gain_output_ratio_coeffs[num_effect][13]
-                + motive_pressure
-                * capacity
-                * gain_output_ratio_coeffs[num_effect][14]
+                + motive_pressure * capacity * gain_output_ratio_coeffs[num_effect][14]
                 + 1 * gain_output_ratio_coeffs[num_effect][15]
-                + motive_pressure**2
-                * gain_output_ratio_coeffs[num_effect][16]
+                + motive_pressure**2 * gain_output_ratio_coeffs[num_effect][16]
                 + capacity**2 * gain_output_ratio_coeffs[num_effect][17]
-                + feed_temperature**2
-                * gain_output_ratio_coeffs[num_effect][18]
+                + feed_temperature**2 * gain_output_ratio_coeffs[num_effect][18]
                 + self.recovery_vol_phase[0, "Liq"] ** 2
                 * gain_output_ratio_coeffs[num_effect][19]
-                + feed_conc_ppm**2
-                * gain_output_ratio_coeffs[num_effect][20]
+                + feed_conc_ppm**2 * gain_output_ratio_coeffs[num_effect][20]
             )
 
         specific_area_coeffs = self._get_specific_area_coeffs()
 
         # Specific area surrogate equation, as a function of the number of effect
         def _get_specific_area(num_effect):
-            return ( 
+            return (
                 feed_conc_ppm * specific_area_coeffs[num_effect][0]
                 + self.recovery_vol_phase[0, "Liq"]
                 * specific_area_coeffs[num_effect][1]
@@ -465,41 +457,29 @@ class MEDTVCData(UnitModelBlockData):
                 * self.recovery_vol_phase[0, "Liq"]
                 * specific_area_coeffs[num_effect][2]
                 + feed_temperature * specific_area_coeffs[num_effect][3]
-                + feed_temperature
-                * feed_conc_ppm
-                * specific_area_coeffs[num_effect][4]
+                + feed_temperature * feed_conc_ppm * specific_area_coeffs[num_effect][4]
                 + feed_temperature
                 * self.recovery_vol_phase[0, "Liq"]
                 * specific_area_coeffs[num_effect][5]
                 + capacity * specific_area_coeffs[num_effect][6]
-                + capacity
-                * feed_conc_ppm
-                * specific_area_coeffs[num_effect][7]
+                + capacity * feed_conc_ppm * specific_area_coeffs[num_effect][7]
                 + capacity
                 * self.recovery_vol_phase[0, "Liq"]
                 * specific_area_coeffs[num_effect][8]
-                + capacity
-                * feed_temperature
-                * specific_area_coeffs[num_effect][9]
+                + capacity * feed_temperature * specific_area_coeffs[num_effect][9]
                 + motive_pressure * specific_area_coeffs[num_effect][10]
-                + motive_pressure
-                * feed_conc_ppm
-                * specific_area_coeffs[num_effect][11]
+                + motive_pressure * feed_conc_ppm * specific_area_coeffs[num_effect][11]
                 + motive_pressure
                 * self.recovery_vol_phase[0, "Liq"]
                 * specific_area_coeffs[num_effect][12]
                 + motive_pressure
                 * feed_temperature
                 * specific_area_coeffs[num_effect][13]
-                + motive_pressure
-                * capacity
-                * specific_area_coeffs[num_effect][14]
+                + motive_pressure * capacity * specific_area_coeffs[num_effect][14]
                 + 1 * specific_area_coeffs[num_effect][15]
-                + motive_pressure**2
-                * specific_area_coeffs[num_effect][16]
+                + motive_pressure**2 * specific_area_coeffs[num_effect][16]
                 + capacity**2 * specific_area_coeffs[num_effect][17]
-                + feed_temperature**2
-                * specific_area_coeffs[num_effect][18]
+                + feed_temperature**2 * specific_area_coeffs[num_effect][18]
                 + self.recovery_vol_phase[0, "Liq"] ** 2
                 * specific_area_coeffs[num_effect][19]
                 + feed_conc_ppm**2 * specific_area_coeffs[num_effect][20]
@@ -512,23 +492,20 @@ class MEDTVCData(UnitModelBlockData):
         # Heating steam mass flow rate surrogate equation, as a function of the number of effect
         def _get_heating_steam_mass_flow_rate(num_effect):
             return (
-                feed_conc_ppm
-                * heating_steam_mass_flow_rate_coeffs[num_effect][0]
+                feed_conc_ppm * heating_steam_mass_flow_rate_coeffs[num_effect][0]
                 + self.recovery_vol_phase[0, "Liq"]
                 * heating_steam_mass_flow_rate_coeffs[num_effect][1]
                 + feed_conc_ppm
                 * self.recovery_vol_phase[0, "Liq"]
                 * heating_steam_mass_flow_rate_coeffs[num_effect][2]
-                + feed_temperature
-                * heating_steam_mass_flow_rate_coeffs[num_effect][3]
+                + feed_temperature * heating_steam_mass_flow_rate_coeffs[num_effect][3]
                 + feed_temperature
                 * feed_conc_ppm
                 * heating_steam_mass_flow_rate_coeffs[num_effect][4]
                 + feed_temperature
                 * self.recovery_vol_phase[0, "Liq"]
                 * heating_steam_mass_flow_rate_coeffs[num_effect][5]
-                + capacity
-                * heating_steam_mass_flow_rate_coeffs[num_effect][6]
+                + capacity * heating_steam_mass_flow_rate_coeffs[num_effect][6]
                 + capacity
                 * feed_conc_ppm
                 * heating_steam_mass_flow_rate_coeffs[num_effect][7]
@@ -538,8 +515,7 @@ class MEDTVCData(UnitModelBlockData):
                 + capacity
                 * feed_temperature
                 * heating_steam_mass_flow_rate_coeffs[num_effect][9]
-                + motive_pressure
-                * heating_steam_mass_flow_rate_coeffs[num_effect][10]
+                + motive_pressure * heating_steam_mass_flow_rate_coeffs[num_effect][10]
                 + motive_pressure
                 * feed_conc_ppm
                 * heating_steam_mass_flow_rate_coeffs[num_effect][11]
@@ -555,8 +531,7 @@ class MEDTVCData(UnitModelBlockData):
                 + 1 * heating_steam_mass_flow_rate_coeffs[num_effect][15]
                 + motive_pressure**2
                 * heating_steam_mass_flow_rate_coeffs[num_effect][16]
-                + capacity**2
-                * heating_steam_mass_flow_rate_coeffs[num_effect][17]
+                + capacity**2 * heating_steam_mass_flow_rate_coeffs[num_effect][17]
                 + feed_temperature**2
                 * heating_steam_mass_flow_rate_coeffs[num_effect][18]
                 + self.recovery_vol_phase[0, "Liq"] ** 2
@@ -565,7 +540,6 @@ class MEDTVCData(UnitModelBlockData):
                 * heating_steam_mass_flow_rate_coeffs[num_effect][20]
             )
 
-
         motive_steam_mass_flow_rate_coeffs = (
             self._get_motive_steam_mass_flow_rate_coeffs()
         )
@@ -573,23 +547,20 @@ class MEDTVCData(UnitModelBlockData):
         # Motive steam mass flow rate surrogate equation, as a function of the number of effect
         def _get_motive_steam_mass_flow_rate(num_effect):
             return (
-                feed_conc_ppm
-                * motive_steam_mass_flow_rate_coeffs[num_effect][0]
+                feed_conc_ppm * motive_steam_mass_flow_rate_coeffs[num_effect][0]
                 + self.recovery_vol_phase[0, "Liq"]
                 * motive_steam_mass_flow_rate_coeffs[num_effect][1]
                 + feed_conc_ppm
                 * self.recovery_vol_phase[0, "Liq"]
                 * motive_steam_mass_flow_rate_coeffs[num_effect][2]
-                + feed_temperature
-                * motive_steam_mass_flow_rate_coeffs[num_effect][3]
+                + feed_temperature * motive_steam_mass_flow_rate_coeffs[num_effect][3]
                 + feed_temperature
                 * feed_conc_ppm
                 * motive_steam_mass_flow_rate_coeffs[num_effect][4]
                 + feed_temperature
                 * self.recovery_vol_phase[0, "Liq"]
                 * motive_steam_mass_flow_rate_coeffs[num_effect][5]
-                + capacity
-                * motive_steam_mass_flow_rate_coeffs[num_effect][6]
+                + capacity * motive_steam_mass_flow_rate_coeffs[num_effect][6]
                 + capacity
                 * feed_conc_ppm
                 * motive_steam_mass_flow_rate_coeffs[num_effect][7]
@@ -599,8 +570,7 @@ class MEDTVCData(UnitModelBlockData):
                 + capacity
                 * feed_temperature
                 * motive_steam_mass_flow_rate_coeffs[num_effect][9]
-                + motive_pressure
-                * motive_steam_mass_flow_rate_coeffs[num_effect][10]
+                + motive_pressure * motive_steam_mass_flow_rate_coeffs[num_effect][10]
                 + motive_pressure
                 * feed_conc_ppm
                 * motive_steam_mass_flow_rate_coeffs[num_effect][11]
@@ -616,8 +586,7 @@ class MEDTVCData(UnitModelBlockData):
                 + 1 * motive_steam_mass_flow_rate_coeffs[num_effect][15]
                 + motive_pressure**2
                 * motive_steam_mass_flow_rate_coeffs[num_effect][16]
-                + capacity**2
-                * motive_steam_mass_flow_rate_coeffs[num_effect][17]
+                + capacity**2 * motive_steam_mass_flow_rate_coeffs[num_effect][17]
                 + feed_temperature**2
                 * motive_steam_mass_flow_rate_coeffs[num_effect][18]
                 + self.recovery_vol_phase[0, "Liq"] ** 2
@@ -630,30 +599,34 @@ class MEDTVCData(UnitModelBlockData):
         # For intermediate number of effects (9,11,13,15), linear interpolation is adopted
         @self.Constraint(doc="Gain output ratio surrogate equation")
         def eq_gain_output_ratio(b):
-            if b.config.number_effects in [8,10,12,14,16]:
-                return (
-                    b.gain_output_ratio
-                    == _get_gain_output_ratio(b.config.number_effects)
+            if b.config.number_effects in [8, 10, 12, 14, 16]:
+                return b.gain_output_ratio == _get_gain_output_ratio(
+                    b.config.number_effects
                 )
-            else: # number_effects in [9,11,13,15]
+            else:  # number_effects in [9,11,13,15]
                 return (
                     b.gain_output_ratio
-                    == (_get_gain_output_ratio(b.config.number_effects - 1) +
-                    _get_gain_output_ratio(b.config.number_effects + 1)) / 2
+                    == (
+                        _get_gain_output_ratio(b.config.number_effects - 1)
+                        + _get_gain_output_ratio(b.config.number_effects + 1)
+                    )
+                    / 2
                 )
 
         @self.Constraint(doc="specific area surrogate equation")
         def eq_specific_area(b):
-            if b.config.number_effects in [8,10,12,14,16]:
-                return (
-                    b.specific_area_per_m3_day
-                    == _get_specific_area(b.config.number_effects)
+            if b.config.number_effects in [8, 10, 12, 14, 16]:
+                return b.specific_area_per_m3_day == _get_specific_area(
+                    b.config.number_effects
                 )
-            else: # number_effects in [9,11,13,15]
+            else:  # number_effects in [9,11,13,15]
                 return (
                     b.specific_area_per_m3_day
-                    == (_get_specific_area(b.config.number_effects - 1) +
-                    _get_specific_area(b.config.number_effects + 1)) / 2
+                    == (
+                        _get_specific_area(b.config.number_effects - 1)
+                        + _get_specific_area(b.config.number_effects + 1)
+                    )
+                    / 2
                 )
 
         @self.Constraint(doc="Convert specific area to m2/kg/s for CAPEX calculation")
@@ -665,30 +638,34 @@ class MEDTVCData(UnitModelBlockData):
 
         @self.Constraint(doc="heating steam mass flow rate surrogate equation")
         def eq_heating_steam_mass_flow_rate(b):
-            if b.config.number_effects in [8,10,12,14,16]:
+            if b.config.number_effects in [8, 10, 12, 14, 16]:
+                return b.heating_steam_props[0].flow_mass_phase_comp[
+                    "Vap", "H2O"
+                ] == _get_heating_steam_mass_flow_rate(b.config.number_effects)
+            else:  # number_effects in [9,11,13,15]
                 return (
                     b.heating_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
-                    == _get_heating_steam_mass_flow_rate(b.config.number_effects)
-                )
-            else: # number_effects in [9,11,13,15]
-                return (
-                    b.heating_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
-                    == (_get_heating_steam_mass_flow_rate(b.config.number_effects - 1) +
-                    _get_heating_steam_mass_flow_rate(b.config.number_effects + 1)) / 2
+                    == (
+                        _get_heating_steam_mass_flow_rate(b.config.number_effects - 1)
+                        + _get_heating_steam_mass_flow_rate(b.config.number_effects + 1)
+                    )
+                    / 2
                 )
 
         @self.Constraint(doc="motive steam mass flow rate surrogate equation")
         def eq_motive_steam_mass_flow_rate(b):
-            if b.config.number_effects in [8,10,12,14,16]:
+            if b.config.number_effects in [8, 10, 12, 14, 16]:
+                return b.motive_steam_props[0].flow_mass_phase_comp[
+                    "Vap", "H2O"
+                ] == _get_motive_steam_mass_flow_rate(b.config.number_effects)
+            else:  # number_effects in [9,11,13,15]
                 return (
                     b.motive_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
-                    == _get_motive_steam_mass_flow_rate(b.config.number_effects)
-                )
-            else: # number_effects in [9,11,13,15]
-                return (
-                    b.motive_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
-                    == (_get_motive_steam_mass_flow_rate(b.config.number_effects - 1) +
-                    _get_motive_steam_mass_flow_rate(b.config.number_effects + 1)) / 2
+                    == (
+                        _get_motive_steam_mass_flow_rate(b.config.number_effects - 1)
+                        + _get_motive_steam_mass_flow_rate(b.config.number_effects + 1)
+                    )
+                    / 2
                 )
 
         # Energy consumption

--- a/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/med_tvc_surrogate.py
@@ -136,7 +136,9 @@ class MEDTVCData(UnitModelBlockData):
 
         # Check if the number of effects is valid
         if self.config.number_effects not in [i for i in range(8, 17)]:
-            raise ConfigurationError("The number of effects should be an integer between 8 to 16")
+            raise ConfigurationError(
+                "The number of effects should be an integer between 8 to 16"
+            )
 
         """
         Add system configurations
@@ -421,7 +423,7 @@ class MEDTVCData(UnitModelBlockData):
                 return b.gain_output_ratio == self._get_gain_output_ratio(
                     b.config.number_effects
                 )
-            else: # b.config.number_effects in [9, 11, 13, 15]:
+            else:  # b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.gain_output_ratio
                     == (
@@ -437,7 +439,7 @@ class MEDTVCData(UnitModelBlockData):
                 return b.specific_area_per_m3_day == self._get_specific_area(
                     b.config.number_effects
                 )
-            else: # b.config.number_effects in [9, 11, 13, 15]:
+            else:  # b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.specific_area_per_m3_day
                     == (
@@ -460,12 +462,16 @@ class MEDTVCData(UnitModelBlockData):
                 return b.heating_steam_props[0].flow_mass_phase_comp[
                     "Vap", "H2O"
                 ] == self._get_heating_steam_mass_flow_rate(b.config.number_effects)
-            else: # b.config.number_effects in [9, 11, 13, 15]:
+            else:  # b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.heating_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
                     == (
-                        self._get_heating_steam_mass_flow_rate(b.config.number_effects - 1)
-                        + self._get_heating_steam_mass_flow_rate(b.config.number_effects + 1)
+                        self._get_heating_steam_mass_flow_rate(
+                            b.config.number_effects - 1
+                        )
+                        + self._get_heating_steam_mass_flow_rate(
+                            b.config.number_effects + 1
+                        )
                     )
                     / 2
                 )
@@ -476,12 +482,16 @@ class MEDTVCData(UnitModelBlockData):
                 return b.motive_steam_props[0].flow_mass_phase_comp[
                     "Vap", "H2O"
                 ] == self._get_motive_steam_mass_flow_rate(b.config.number_effects)
-            else: # b.config.number_effects in [9, 11, 13, 15]:
+            else:  # b.config.number_effects in [9, 11, 13, 15]:
                 return (
                     b.motive_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
                     == (
-                        self._get_motive_steam_mass_flow_rate(b.config.number_effects - 1)
-                        + self._get_motive_steam_mass_flow_rate(b.config.number_effects + 1)
+                        self._get_motive_steam_mass_flow_rate(
+                            b.config.number_effects - 1
+                        )
+                        + self._get_motive_steam_mass_flow_rate(
+                            b.config.number_effects + 1
+                        )
                     )
                     / 2
                 )
@@ -1341,11 +1351,15 @@ class MEDTVCData(UnitModelBlockData):
             * self.recovery_vol_phase[0, "Liq"]
             * self.gain_output_ratio_coeffs[num_effect][5]
             + self.capacity * self.gain_output_ratio_coeffs[num_effect][6]
-            + self.capacity * self.feed_conc_ppm * self.gain_output_ratio_coeffs[num_effect][7]
+            + self.capacity
+            * self.feed_conc_ppm
+            * self.gain_output_ratio_coeffs[num_effect][7]
             + self.capacity
             * self.recovery_vol_phase[0, "Liq"]
             * self.gain_output_ratio_coeffs[num_effect][8]
-            + self.capacity * self.feed_temperature * self.gain_output_ratio_coeffs[num_effect][9]
+            + self.capacity
+            * self.feed_temperature
+            * self.gain_output_ratio_coeffs[num_effect][9]
             + self.motive_pressure * self.gain_output_ratio_coeffs[num_effect][10]
             + self.motive_pressure
             * self.feed_conc_ppm
@@ -1356,7 +1370,9 @@ class MEDTVCData(UnitModelBlockData):
             + self.motive_pressure
             * self.feed_temperature
             * self.gain_output_ratio_coeffs[num_effect][13]
-            + self.motive_pressure * self.capacity * self.gain_output_ratio_coeffs[num_effect][14]
+            + self.motive_pressure
+            * self.capacity
+            * self.gain_output_ratio_coeffs[num_effect][14]
             + 1 * self.gain_output_ratio_coeffs[num_effect][15]
             + self.motive_pressure**2 * self.gain_output_ratio_coeffs[num_effect][16]
             + self.capacity**2 * self.gain_output_ratio_coeffs[num_effect][17]
@@ -1376,25 +1392,35 @@ class MEDTVCData(UnitModelBlockData):
             * self.recovery_vol_phase[0, "Liq"]
             * self.specific_area_coeffs[num_effect][2]
             + self.feed_temperature * self.specific_area_coeffs[num_effect][3]
-            + self.feed_temperature * self.feed_conc_ppm * self.specific_area_coeffs[num_effect][4]
+            + self.feed_temperature
+            * self.feed_conc_ppm
+            * self.specific_area_coeffs[num_effect][4]
             + self.feed_temperature
             * self.recovery_vol_phase[0, "Liq"]
             * self.specific_area_coeffs[num_effect][5]
             + self.capacity * self.specific_area_coeffs[num_effect][6]
-            + self.capacity * self.feed_conc_ppm * self.specific_area_coeffs[num_effect][7]
+            + self.capacity
+            * self.feed_conc_ppm
+            * self.specific_area_coeffs[num_effect][7]
             + self.capacity
             * self.recovery_vol_phase[0, "Liq"]
             * self.specific_area_coeffs[num_effect][8]
-            + self.capacity * self.feed_temperature * self.specific_area_coeffs[num_effect][9]
+            + self.capacity
+            * self.feed_temperature
+            * self.specific_area_coeffs[num_effect][9]
             + self.motive_pressure * self.specific_area_coeffs[num_effect][10]
-            + self.motive_pressure * self.feed_conc_ppm * self.specific_area_coeffs[num_effect][11]
+            + self.motive_pressure
+            * self.feed_conc_ppm
+            * self.specific_area_coeffs[num_effect][11]
             + self.motive_pressure
             * self.recovery_vol_phase[0, "Liq"]
             * self.specific_area_coeffs[num_effect][12]
             + self.motive_pressure
             * self.feed_temperature
             * self.specific_area_coeffs[num_effect][13]
-            + self.motive_pressure * self.capacity * self.specific_area_coeffs[num_effect][14]
+            + self.motive_pressure
+            * self.capacity
+            * self.specific_area_coeffs[num_effect][14]
             + 1 * self.specific_area_coeffs[num_effect][15]
             + self.motive_pressure**2 * self.specific_area_coeffs[num_effect][16]
             + self.capacity**2 * self.specific_area_coeffs[num_effect][17]
@@ -1413,7 +1439,8 @@ class MEDTVCData(UnitModelBlockData):
             + self.feed_conc_ppm
             * self.recovery_vol_phase[0, "Liq"]
             * self.heating_steam_mass_flow_rate_coeffs[num_effect][2]
-            + self.feed_temperature * self.heating_steam_mass_flow_rate_coeffs[num_effect][3]
+            + self.feed_temperature
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][3]
             + self.feed_temperature
             * self.feed_conc_ppm
             * self.heating_steam_mass_flow_rate_coeffs[num_effect][4]
@@ -1430,7 +1457,8 @@ class MEDTVCData(UnitModelBlockData):
             + self.capacity
             * self.feed_temperature
             * self.heating_steam_mass_flow_rate_coeffs[num_effect][9]
-            + self.motive_pressure * self.heating_steam_mass_flow_rate_coeffs[num_effect][10]
+            + self.motive_pressure
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][10]
             + self.motive_pressure
             * self.feed_conc_ppm
             * self.heating_steam_mass_flow_rate_coeffs[num_effect][11]
@@ -1446,7 +1474,8 @@ class MEDTVCData(UnitModelBlockData):
             + 1 * self.heating_steam_mass_flow_rate_coeffs[num_effect][15]
             + self.motive_pressure**2
             * self.heating_steam_mass_flow_rate_coeffs[num_effect][16]
-            + self.capacity**2 * self.heating_steam_mass_flow_rate_coeffs[num_effect][17]
+            + self.capacity**2
+            * self.heating_steam_mass_flow_rate_coeffs[num_effect][17]
             + self.feed_temperature**2
             * self.heating_steam_mass_flow_rate_coeffs[num_effect][18]
             + self.recovery_vol_phase[0, "Liq"] ** 2
@@ -1464,7 +1493,8 @@ class MEDTVCData(UnitModelBlockData):
             + self.feed_conc_ppm
             * self.recovery_vol_phase[0, "Liq"]
             * self.motive_steam_mass_flow_rate_coeffs[num_effect][2]
-            + self.feed_temperature * self.motive_steam_mass_flow_rate_coeffs[num_effect][3]
+            + self.feed_temperature
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][3]
             + self.feed_temperature
             * self.feed_conc_ppm
             * self.motive_steam_mass_flow_rate_coeffs[num_effect][4]
@@ -1481,7 +1511,8 @@ class MEDTVCData(UnitModelBlockData):
             + self.capacity
             * self.feed_temperature
             * self.motive_steam_mass_flow_rate_coeffs[num_effect][9]
-            + self.motive_pressure * self.motive_steam_mass_flow_rate_coeffs[num_effect][10]
+            + self.motive_pressure
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][10]
             + self.motive_pressure
             * self.feed_conc_ppm
             * self.motive_steam_mass_flow_rate_coeffs[num_effect][11]
@@ -1497,7 +1528,8 @@ class MEDTVCData(UnitModelBlockData):
             + 1 * self.motive_steam_mass_flow_rate_coeffs[num_effect][15]
             + self.motive_pressure**2
             * self.motive_steam_mass_flow_rate_coeffs[num_effect][16]
-            + self.capacity**2 * self.motive_steam_mass_flow_rate_coeffs[num_effect][17]
+            + self.capacity**2
+            * self.motive_steam_mass_flow_rate_coeffs[num_effect][17]
             + self.feed_temperature**2
             * self.motive_steam_mass_flow_rate_coeffs[num_effect][18]
             + self.recovery_vol_phase[0, "Liq"] ** 2

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_lt_med_surrogate.py
@@ -109,6 +109,80 @@ class TestLTMED:
 
         return m
 
+    @pytest.fixture(scope="class")
+    def LT_MED_frame2(self):
+        # create flowsheet for an interpolated number of effects
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+        m.fs.water_prop = SeawaterParameterBlock()
+        m.fs.steam_prop = WaterParameterBlock()
+        m.fs.lt_med = LTMEDSurrogate(
+            property_package_liquid=m.fs.water_prop,
+            property_package_vapor=m.fs.steam_prop,
+            number_effects=7,  # Interpolated values include [4,5,7,8,10,11,13]
+        )
+
+        lt_med = m.fs.lt_med
+        feed = lt_med.feed_props[0]
+        dist = lt_med.distillate_props[0]
+        steam = lt_med.steam_props[0]
+
+        # System specification
+        # Input variable 1: Feed salinity (30-60 g/L = kg/m3)
+        feed_salinity = 35 * pyunits.kg / pyunits.m**3  # g/L = kg/m3
+
+        # Input variable 2: Feed temperature (15-35 deg C)
+        feed_temperature = 25  # degC
+
+        # Input variable 3: Heating steam temperature (60-85 deg C)
+        steam_temperature = 80  # degC
+
+        # Input variable 4: System capacity (> 2000 m3/day)
+        sys_capacity = 2000 * pyunits.m**3 / pyunits.day  # m3/day
+
+        # Input variable 5: Recovery ratio (30%- 50%)
+        recovery_ratio = 0.5 * pyunits.dimensionless  # dimensionless
+
+        feed_flow = pyunits.convert(
+            (sys_capacity / recovery_ratio), to_units=pyunits.m**3 / pyunits.s
+        )
+
+        """
+        Specify feed flow state properties
+        """
+        # Specify feed flow state properties
+        lt_med.feed_props.calculate_state(
+            var_args={
+                ("flow_vol_phase", "Liq"): feed_flow,
+                ("conc_mass_phase_comp", ("Liq", "TDS")): feed_salinity,
+                ("temperature", None): feed_temperature + 273.15,
+                # feed flow is at atmospheric pressure
+                ("pressure", None): 101325,
+            },
+            hold_state=True,
+        )
+
+        # Fix input steam temperature
+        steam.temperature.fix(steam_temperature + 273.15)
+
+        # Fix target recovery rate
+        lt_med.recovery_vol_phase[0, "Liq"].fix(recovery_ratio)
+
+        m.fs.water_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
+        )
+        m.fs.water_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e3, index=("Liq", "TDS")
+        )
+        m.fs.steam_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
+        )
+        m.fs.steam_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1, index=("Vap", "H2O")
+        )
+
+        return m
+
     @pytest.mark.unit
     def test_config(self, LT_MED_frame):
         m = LT_MED_frame
@@ -134,7 +208,7 @@ class TestLTMED:
 
         # test statistics
         assert number_variables(m) == 193
-        assert number_total_constraints(m) == 53
+        assert number_total_constraints(m) == 52
         assert number_unused_variables(m) == 89  # vars from property package parameters
 
     @pytest.mark.unit
@@ -235,6 +309,12 @@ class TestLTMED:
         assert pytest.approx(2.321, rel=1e-3) == value(
             m.fs.lt_med.steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
         )
+        assert pytest.approx(406.00, rel=1e-3) == value(
+            pyunits.convert(
+                m.fs.lt_med.cooling_out_props[0].flow_vol_phase["Liq"],
+                to_units=pyunits.m**3 / pyunits.hr,
+            )
+        )
 
     @pytest.mark.component
     def test_costing(self, LT_MED_frame):
@@ -282,4 +362,31 @@ class TestLTMED:
         )
         assert pytest.approx(4662455.768, rel=1e-3) == value(
             m.fs.costing.total_capital_cost
+        )
+
+    @pytest.mark.component
+    def test_solution2(self, LT_MED_frame2):
+        # Test the solution for 7 effects
+        m = LT_MED_frame2
+        initialization_tester(m, unit=m.fs.lt_med, outlvl=idaeslog.DEBUG)
+        results = solver.solve(m)
+
+        assert pytest.approx(6.073, rel=1e-3) == value(m.fs.lt_med.gain_output_ratio)
+        assert pytest.approx(2.507, rel=1e-3) == value(
+            m.fs.lt_med.specific_area_per_m3_day
+        )
+        assert pytest.approx(104.93, rel=1e-3) == value(
+            m.fs.lt_med.specific_energy_consumption_thermal
+        )
+        assert pytest.approx(8744.31, rel=1e-3) == value(
+            m.fs.lt_med.thermal_power_requirement
+        )
+        assert pytest.approx(3.788, rel=1e-3) == value(
+            m.fs.lt_med.steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
+        )
+        assert pytest.approx(816.53, rel=1e-3) == value(
+            pyunits.convert(
+                m.fs.lt_med.cooling_out_props[0].flow_vol_phase["Liq"],
+                to_units=pyunits.m**3 / pyunits.hr,
+            )
         )

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_lt_med_surrogate.py
@@ -45,7 +45,7 @@ class TestLTMED:
         m.fs.lt_med = LTMEDSurrogate(
             property_package_liquid=m.fs.water_prop,
             property_package_vapor=m.fs.steam_prop,
-            number_effects=12, # assuming 12 effects by default
+            number_effects=12,  # assuming 12 effects by default
         )
 
         lt_med = m.fs.lt_med
@@ -90,7 +90,7 @@ class TestLTMED:
 
         # Fix input steam temperature
         steam.temperature.fix(steam_temperature + 273.15)
-        
+
         # Fix target recovery rate
         lt_med.recovery_vol_phase[0, "Liq"].fix(recovery_ratio)
 
@@ -223,7 +223,9 @@ class TestLTMED:
     def test_solution(self, LT_MED_frame):
         m = LT_MED_frame
         assert pytest.approx(9.9127, rel=1e-3) == value(m.fs.lt_med.gain_output_ratio)
-        assert pytest.approx(3.9592, rel=1e-3) == value(m.fs.lt_med.specific_area_per_m3_day)
+        assert pytest.approx(3.9592, rel=1e-3) == value(
+            m.fs.lt_med.specific_area_per_m3_day
+        )
         assert pytest.approx(6.4290e1, rel=1e-3) == value(
             m.fs.lt_med.specific_energy_consumption_thermal
         )

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_lt_med_surrogate.py
@@ -45,7 +45,7 @@ class TestLTMED:
         m.fs.lt_med = LTMEDSurrogate(
             property_package_liquid=m.fs.liquid_prop,
             property_package_vapor=m.fs.vapor_prop,
-            number_effects=9,  # assuming 12 effects by default
+            number_effects=12,  # assuming 12 effects by default
         )
 
         lt_med = m.fs.lt_med
@@ -107,7 +107,6 @@ class TestLTMED:
             "flow_mass_phase_comp", 1, index=("Vap", "H2O")
         )
 
-
         return m
 
     @pytest.mark.unit
@@ -122,7 +121,7 @@ class TestLTMED:
             m.fs.lt_med = LTMEDSurrogate(
                 property_package_liquid=m.fs.liquid_prop,
                 property_package_vapor=m.fs.vapor_prop,
-                number_effects=15,  
+                number_effects=15,
             )
 
     @pytest.mark.unit
@@ -306,88 +305,109 @@ class TestLTMED:
             m.fs.costing.total_capital_cost
         )
 
-    # @pytest.mark.parametrize("number_effects", [12])
-    # def test_interp_values(self, number_effects):
-    #     # create flowsheet with interpolated values of number of effects
-    #     m = ConcreteModel()
-    #     m.fs = FlowsheetBlock(dynamic=False)
-    #     m.fs.liquid_prop = SeawaterParameterBlock()
-    #     m.fs.vapor_prop = WaterParameterBlock()
-    #     m.fs.lt_med = LTMEDSurrogate(
-    #         property_package_liquid=m.fs.liquid_prop,
-    #         property_package_vapor=m.fs.vapor_prop,
-    #         number_effects=number_effects, 
-    #     )
+    @pytest.mark.parametrize("number_effects", [4, 5, 7, 8, 10, 11, 13])
+    def test_interp_values(self, number_effects):
+        # create flowsheet with interpolated values of number of effects
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+        m.fs.liquid_prop = SeawaterParameterBlock()
+        m.fs.vapor_prop = WaterParameterBlock()
+        m.fs.lt_med = LTMEDSurrogate(
+            property_package_liquid=m.fs.liquid_prop,
+            property_package_vapor=m.fs.vapor_prop,
+            number_effects=number_effects,
+        )
 
-    #     lt_med = m.fs.lt_med
-    #     feed = lt_med.feed_props[0]
-    #     dist = lt_med.distillate_props[0]
-    #     steam = lt_med.steam_props[0]
+        lt_med = m.fs.lt_med
+        feed = lt_med.feed_props[0]
+        dist = lt_med.distillate_props[0]
+        steam = lt_med.steam_props[0]
 
-    #     # System specification
-    #     # Input variable 1: Feed salinity (30-60 g/L = kg/m3)
-    #     feed_salinity = 35 * pyunits.kg / pyunits.m**3  # g/L = kg/m3
+        # System specification
+        # Input variable 1: Feed salinity (30-60 g/L = kg/m3)
+        feed_salinity = 35 * pyunits.kg / pyunits.m**3  # g/L = kg/m3
 
-    #     # Input variable 2: Feed temperature (15-35 deg C)
-    #     feed_temperature = 25  # degC
+        # Input variable 2: Feed temperature (15-35 deg C)
+        feed_temperature = 25  # degC
 
-    #     # Input variable 3: Heating steam temperature (60-85 deg C)
-    #     steam_temperature = 80  # degC
+        # Input variable 3: Heating steam temperature (60-85 deg C)
+        steam_temperature = 80  # degC
 
-    #     # Input variable 4: System capacity (> 2000 m3/day)
-    #     sys_capacity = 2000 * pyunits.m**3 / pyunits.day  # m3/day
+        # Input variable 4: System capacity (> 2000 m3/day)
+        sys_capacity = 2000 * pyunits.m**3 / pyunits.day  # m3/day
 
-    #     # Input variable 5: Recovery ratio (30%- 50%)
-    #     recovery_ratio = 0.5 * pyunits.dimensionless  # dimensionless
+        # Input variable 5: Recovery ratio (30%- 50%)
+        recovery_ratio = 0.5 * pyunits.dimensionless  # dimensionless
 
-    #     feed_flow = pyunits.convert(
-    #         (sys_capacity / recovery_ratio), to_units=pyunits.m**3 / pyunits.s
-    #     )
+        feed_flow = pyunits.convert(
+            (sys_capacity / recovery_ratio), to_units=pyunits.m**3 / pyunits.s
+        )
 
-    #     """
-    #     Specify feed flow state properties
-    #     """
-    #     # Specify feed flow state properties
-    #     lt_med.feed_props.calculate_state(
-    #         var_args={
-    #             ("flow_vol_phase", "Liq"): feed_flow,
-    #             ("conc_mass_phase_comp", ("Liq", "TDS")): feed_salinity,
-    #             ("temperature", None): feed_temperature + 273.15,
-    #             # feed flow is at atmospheric pressure
-    #             ("pressure", None): 101325,
-    #         },
-    #         hold_state=True,
-    #     )
+        """
+        Specify feed flow state properties
+        """
+        # Specify feed flow state properties
+        lt_med.feed_props.calculate_state(
+            var_args={
+                ("flow_vol_phase", "Liq"): feed_flow,
+                ("conc_mass_phase_comp", ("Liq", "TDS")): feed_salinity,
+                ("temperature", None): feed_temperature + 273.15,
+                # feed flow is at atmospheric pressure
+                ("pressure", None): 101325,
+            },
+            hold_state=True,
+        )
 
-    #     # Fix input steam temperature
-    #     steam.temperature.fix(steam_temperature + 273.15)
+        # Fix input steam temperature
+        steam.temperature.fix(steam_temperature + 273.15)
 
-    #     # Fix target recovery rate
-    #     lt_med.recovery_vol_phase[0, "Liq"].fix(recovery_ratio)
+        # Fix target recovery rate
+        lt_med.recovery_vol_phase[0, "Liq"].fix(recovery_ratio)
 
-    #     m.fs.liquid_prop.set_default_scaling(
-    #         "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
-    #     )
-    #     m.fs.liquid_prop.set_default_scaling(
-    #         "flow_mass_phase_comp", 1e3, index=("Liq", "TDS")
-    #     )
-    #     m.fs.vapor_prop.set_default_scaling(
-    #         "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
-    #     )
-    #     m.fs.vapor_prop.set_default_scaling(
-    #         "flow_mass_phase_comp", 1, index=("Vap", "H2O")
-    #     )
+        m.fs.liquid_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
+        )
+        m.fs.liquid_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e3, index=("Liq", "TDS")
+        )
+        m.fs.vapor_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
+        )
+        m.fs.vapor_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1, index=("Vap", "H2O")
+        )
 
-    #     calculate_scaling_factors(m)
-    #     # m.fs.lt_med.initialize_build()
-    #     initialization_tester(m, unit=m.fs.lt_med, outlvl=idaeslog.DEBUG)
-    #     results = solver.solve(m)
+        calculate_scaling_factors(m)
+        # For 10 and 11 effects, specific area may need a new initialization value,
+        # because the surrogate eqn for 9 and 12 effects are largely different
+        if number_effects == 11:
+            m.fs.lt_med.specific_area_per_m3_day.value = 3
+        initialization_tester(m, unit=m.fs.lt_med, outlvl=idaeslog.DEBUG)
+        results = solver.solve(m)
 
-    #     # Check interpolated results for different number of effects: {number_effects: result}
-    #     gain_output_ratios = {12: 3.584 , 5: 4.431 , 7: 6.073, 8: 6.869 , 10: 8.414, 11: 9.163, 13: 10.626}
-    #     specific_areas = {12: 2.757 , 5: 2.507, 7: 2.507, 8: 2.758 , 10: 3.325, 11: 3.642, 13: 4.159 }
+        # Check interpolated results for different number of effects: {number_effects: result}
+        gain_output_ratios = {
+            4: 3.584,
+            5: 4.431,
+            7: 6.073,
+            8: 6.869,
+            10: 8.414,
+            11: 9.163,
+            13: 10.626,
+        }
+        specific_areas = {
+            4: 2.757,
+            5: 2.507,
+            7: 2.507,
+            8: 2.758,
+            10: 3.325,
+            11: 3.642,
+            13: 4.159,
+        }
 
-    #     assert pytest.approx(gain_output_ratios[number_effects], rel=1e-3) == value(m.fs.lt_med.gain_output_ratio)
-    #     assert pytest.approx(specific_areas[number_effects], rel=1e-3) == value(
-    #         m.fs.lt_med.specific_area_per_m3_day
-    #     )
+        assert pytest.approx(gain_output_ratios[number_effects], rel=1e-3) == value(
+            m.fs.lt_med.gain_output_ratio
+        )
+        assert pytest.approx(specific_areas[number_effects], rel=1e-3) == value(
+            m.fs.lt_med.specific_area_per_m3_day
+        )

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
@@ -160,7 +160,7 @@ class TestMEDTVC:
             m.fs.lt_med = MEDTVCSurrogate(
                 property_package_liquid=m.fs.water_prop,
                 property_package_vapor=m.fs.steam_prop,
-                number_effects=17,  
+                number_effects=17,
             )
 
     @pytest.mark.unit
@@ -347,7 +347,7 @@ class TestMEDTVC:
             m.fs.costing.total_capital_cost
         )
 
-    @pytest.mark.parametrize("number_effects", [9,11,13,15])
+    @pytest.mark.parametrize("number_effects", [9, 11, 13, 15])
     def test_interp_values(self, number_effects):
         # create flowsheet for an interpolated number of effects
         m = ConcreteModel()
@@ -450,25 +450,30 @@ class TestMEDTVC:
         m.fs.vapor_prop.set_default_scaling(
             "flow_mass_phase_comp", 1, index=("Vap", "H2O")
         )
-        
+
         calculate_scaling_factors(m)
         initialization_tester(m, unit=m.fs.med_tvc, outlvl=idaeslog.DEBUG)
-        results = solver.solve(m)        
-
+        results = solver.solve(m)
 
         # Check interpolated results for different number of effects: {number_effects: result}
-        gain_output_ratios = {9: 10.299 , 11: 12.067 , 13: 13.709, 15: 15.218}
-        specific_areas = {9: 3.514 , 11: 4.682 , 13: 5.797, 15: 7.689}
-        heating_steam_mass_flow_rates = {9: 2.642 , 11: 2.834 , 13: 2.518, 15: 2.786}
-        motive_steam_mass_flow_rates = {9: 1.162 , 11: 1.334 , 13: 1.152, 15: 1.407}
-        
-        assert pytest.approx(gain_output_ratios[number_effects], rel=1e-3) == value(m.fs.med_tvc.gain_output_ratio)
+        gain_output_ratios = {9: 10.299, 11: 12.067, 13: 13.709, 15: 15.218}
+        specific_areas = {9: 3.514, 11: 4.682, 13: 5.797, 15: 7.689}
+        heating_steam_mass_flow_rates = {9: 2.642, 11: 2.834, 13: 2.518, 15: 2.786}
+        motive_steam_mass_flow_rates = {9: 1.162, 11: 1.334, 13: 1.152, 15: 1.407}
+
+        assert pytest.approx(gain_output_ratios[number_effects], rel=1e-3) == value(
+            m.fs.med_tvc.gain_output_ratio
+        )
         assert pytest.approx(specific_areas[number_effects], rel=1e-3) == value(
             m.fs.med_tvc.specific_area_per_m3_day
         )
-        assert pytest.approx(heating_steam_mass_flow_rates[number_effects], rel=1e-3) == value(
+        assert pytest.approx(
+            heating_steam_mass_flow_rates[number_effects], rel=1e-3
+        ) == value(
             m.fs.med_tvc.heating_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
         )
-        assert pytest.approx(motive_steam_mass_flow_rates[number_effects], rel=1e-3) == value(
+        assert pytest.approx(
+            motive_steam_mass_flow_rates[number_effects], rel=1e-3
+        ) == value(
             m.fs.med_tvc.motive_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
         )

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
@@ -52,7 +52,7 @@ class TestMEDTVC:
         m.fs.med_tvc = MEDTVCSurrogate(
             property_package_liquid=m.fs.liquid_prop,
             property_package_vapor=m.fs.vapor_prop,
-            number_effects=12,
+            number_effects=12, # assuming 12 effects by default
         )
 
         med_tvc = m.fs.med_tvc
@@ -152,21 +152,13 @@ class TestMEDTVC:
     def test_config(self, MED_TVC_frame):
         m = MED_TVC_frame
         # check unit config arguments
-        assert len(m.fs.med_tvc.config) == 5
+        assert len(m.fs.med_tvc.config) == 6
 
         assert not m.fs.med_tvc.config.dynamic
         assert not m.fs.med_tvc.config.has_holdup
         assert m.fs.med_tvc.config.property_package_liquid is m.fs.liquid_prop
         assert m.fs.med_tvc.config.property_package_vapor is m.fs.vapor_prop
-
-    @pytest.mark.unit
-    def test_num_effects_domain(self, MED_TVC_frame):
-        m = MED_TVC_frame
-        error_msg = re.escape(
-            "Invalid parameter value: fs.med_tvc.number_effects[None] = '100', value type=<class 'int'>.\n\tValue not in parameter domain fs.med_tvc.number_effects_domain"
-        )
-        with pytest.raises(ValueError, match=error_msg):
-            m.fs.med_tvc.number_effects.set_value(100)
+        assert m.fs.med_tvc.config.number_effects in range(8, 17)
 
     @pytest.mark.unit
     def test_build(self, MED_TVC_frame):
@@ -180,7 +172,7 @@ class TestMEDTVC:
             assert len(port.vars) == 3
 
         # test statistics
-        assert number_variables(m) == 202
+        assert number_variables(m) == 204
         assert number_total_constraints(m) == 62
         assert number_unused_variables(m) == 74  # vars from property package parameters
 
@@ -265,7 +257,7 @@ class TestMEDTVC:
         assert value(
             med_tvc.brine_props[0].flow_mass_phase_comp["Liq", "TDS"]
             - med_tvc.feed_props[0].flow_mass_phase_comp["Liq", "TDS"]
-        ) == pytest.approx(0, rel=1e-3)
+        ) == pytest.approx(0, abs=1e-3)
 
     @pytest.mark.component
     def test_solution(self, MED_TVC_frame):

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
@@ -52,6 +52,7 @@ class TestMEDTVC:
         m.fs.med_tvc = MEDTVCSurrogate(
             property_package_liquid=m.fs.liquid_prop,
             property_package_vapor=m.fs.vapor_prop,
+            number_effects=12,
         )
 
         med_tvc = m.fs.med_tvc

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
@@ -52,7 +52,7 @@ class TestMEDTVC:
         m.fs.med_tvc = MEDTVCSurrogate(
             property_package_liquid=m.fs.liquid_prop,
             property_package_vapor=m.fs.vapor_prop,
-            number_effects=12, # assuming 12 effects by default
+            number_effects=12,  # assuming 12 effects by default
         )
 
         med_tvc = m.fs.med_tvc

--- a/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/tests/test_med_tvc_surrogate.py
@@ -148,111 +148,20 @@ class TestMEDTVC:
 
         return m
 
-    @pytest.fixture(scope="class")
-    def MED_TVC_frame2(self):
-        # create flowsheet for an interpolated number of effects
+    @pytest.mark.unit
+    def test_num_effects_domain(self):
         m = ConcreteModel()
         m.fs = FlowsheetBlock(dynamic=False)
-        m.fs.liquid_prop = SeawaterParameterBlock()
-        m.fs.vapor_prop = WaterParameterBlock()
-        m.fs.med_tvc = MEDTVCSurrogate(
-            property_package_liquid=m.fs.liquid_prop,
-            property_package_vapor=m.fs.vapor_prop,
-            number_effects=9,  # Interpolated values include [9, 11, 13, 15]
-        )
+        m.fs.water_prop = SeawaterParameterBlock()
+        m.fs.steam_prop = WaterParameterBlock()
 
-        med_tvc = m.fs.med_tvc
-        feed = med_tvc.feed_props[0]
-        cool = med_tvc.cooling_out_props[0]
-        dist = med_tvc.distillate_props[0]
-        steam = med_tvc.heating_steam_props[0]
-        motive = med_tvc.motive_steam_props[0]
-
-        # System specification
-        # Input variable 1: Feed salinity (30-60 g/L = kg/m3)
-        feed_salinity = 35 * pyunits.kg / pyunits.m**3
-
-        # Input variable 2: Feed temperature (25-35 deg C)
-        feed_temperature = 25
-
-        # Input variable 3: Motive steam pressure (4-45 bar)
-        motive_pressure = 24
-
-        # Input variable 4: System capacity (2,000 - 100,000 m3/day)
-        sys_capacity = 2000 * pyunits.m**3 / pyunits.day
-
-        # Input variable 5: Recovery ratio (30%- 40%)
-        recovery_ratio = 0.3 * pyunits.dimensionless
-
-        feed_flow = pyunits.convert(
-            (sys_capacity / recovery_ratio), to_units=pyunits.m**3 / pyunits.s
-        )  # feed volumetric flow rate [m3/s]
-
-        """
-        Specify feed flow state properties
-        """
-        # Specify feed flow state properties
-        med_tvc.feed_props.calculate_state(
-            var_args={
-                ("flow_vol_phase", "Liq"): feed_flow,
-                ("conc_mass_phase_comp", ("Liq", "TDS")): feed_salinity,
-                ("temperature", None): feed_temperature + 273.15,
-                # feed flow is at atmospheric pressure
-                ("pressure", None): 101325,
-            },
-            hold_state=True,
-        )
-
-        """
-        Specify heating steam state properties
-        """
-        # Heating steam temperature (saturated) is fixed at 70 C in this configuration
-        steam.temperature.fix(70 + 273.15)
-
-        # Calculate heating steam pressure (saturated)
-        med_tvc.heating_steam_props.calculate_state(
-            var_args={
-                ("pressure_sat", None): value(steam.pressure),
-            },
-            hold_state=True,
-        )
-        # Release mass flow rate
-        steam.flow_mass_phase_comp["Vap", "H2O"].unfix()
-        steam.flow_mass_phase_comp["Liq", "H2O"].unfix()
-
-        """
-        Specify motive steam state properties
-        """
-        # Calculate temperature of the motive steam (saturated)
-        med_tvc.motive_steam_props.calculate_state(
-            var_args={
-                ("pressure", None): motive_pressure * 1e5,
-                ("pressure_sat", None): motive_pressure * 1e5,
-            },
-            hold_state=True,
-        )
-        # Release mass flow rate
-        motive.flow_mass_phase_comp["Vap", "H2O"].unfix()
-        motive.flow_mass_phase_comp["Liq", "H2O"].unfix()
-
-        # Fix target recovery rate
-        med_tvc.recovery_vol_phase[0, "Liq"].fix(recovery_ratio)
-
-        # Set scaling factors for mass flow rates
-        m.fs.liquid_prop.set_default_scaling(
-            "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
-        )
-        m.fs.liquid_prop.set_default_scaling(
-            "flow_mass_phase_comp", 1e3, index=("Liq", "TDS")
-        )
-        m.fs.vapor_prop.set_default_scaling(
-            "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
-        )
-        m.fs.vapor_prop.set_default_scaling(
-            "flow_mass_phase_comp", 1, index=("Vap", "H2O")
-        )
-
-        return m
+        error_msg = "invalid value for configuration 'number_effects'"
+        with pytest.raises(ValueError, match=error_msg):
+            m.fs.lt_med = MEDTVCSurrogate(
+                property_package_liquid=m.fs.water_prop,
+                property_package_vapor=m.fs.steam_prop,
+                number_effects=17,  
+            )
 
     @pytest.mark.unit
     def test_config(self, MED_TVC_frame):
@@ -438,32 +347,128 @@ class TestMEDTVC:
             m.fs.costing.total_capital_cost
         )
 
-    @pytest.mark.component
-    def test_solution2(self, MED_TVC_frame2):
-        # Test the solution for 9 effects
-        m = MED_TVC_frame2
-        initialization_tester(m, unit=m.fs.med_tvc, outlvl=idaeslog.DEBUG)
-        results = solver.solve(m)
+    @pytest.mark.parametrize("number_effects", [9,11,13,15])
+    def test_interp_values(self, number_effects):
+        # create flowsheet for an interpolated number of effects
+        m = ConcreteModel()
+        m.fs = FlowsheetBlock(dynamic=False)
+        m.fs.liquid_prop = SeawaterParameterBlock()
+        m.fs.vapor_prop = WaterParameterBlock()
+        m.fs.med_tvc = MEDTVCSurrogate(
+            property_package_liquid=m.fs.liquid_prop,
+            property_package_vapor=m.fs.vapor_prop,
+            number_effects=number_effects,  # Interpolated values include [9, 11, 13, 15]
+        )
 
-        assert pytest.approx(10.299, rel=1e-3) == value(m.fs.med_tvc.gain_output_ratio)
-        assert pytest.approx(3.514, rel=1e-3) == value(
+        med_tvc = m.fs.med_tvc
+        feed = med_tvc.feed_props[0]
+        cool = med_tvc.cooling_out_props[0]
+        dist = med_tvc.distillate_props[0]
+        steam = med_tvc.heating_steam_props[0]
+        motive = med_tvc.motive_steam_props[0]
+
+        # System specification
+        # Input variable 1: Feed salinity (30-60 g/L = kg/m3)
+        feed_salinity = 35 * pyunits.kg / pyunits.m**3
+
+        # Input variable 2: Feed temperature (25-35 deg C)
+        feed_temperature = 25
+
+        # Input variable 3: Motive steam pressure (4-45 bar)
+        motive_pressure = 24
+
+        # Input variable 4: System capacity (2,000 - 100,000 m3/day)
+        sys_capacity = 2000 * pyunits.m**3 / pyunits.day
+
+        # Input variable 5: Recovery ratio (30%- 40%)
+        recovery_ratio = 0.3 * pyunits.dimensionless
+
+        feed_flow = pyunits.convert(
+            (sys_capacity / recovery_ratio), to_units=pyunits.m**3 / pyunits.s
+        )  # feed volumetric flow rate [m3/s]
+
+        """
+        Specify feed flow state properties
+        """
+        # Specify feed flow state properties
+        med_tvc.feed_props.calculate_state(
+            var_args={
+                ("flow_vol_phase", "Liq"): feed_flow,
+                ("conc_mass_phase_comp", ("Liq", "TDS")): feed_salinity,
+                ("temperature", None): feed_temperature + 273.15,
+                # feed flow is at atmospheric pressure
+                ("pressure", None): 101325,
+            },
+            hold_state=True,
+        )
+
+        """
+        Specify heating steam state properties
+        """
+        # Heating steam temperature (saturated) is fixed at 70 C in this configuration
+        steam.temperature.fix(70 + 273.15)
+
+        # Calculate heating steam pressure (saturated)
+        med_tvc.heating_steam_props.calculate_state(
+            var_args={
+                ("pressure_sat", None): value(steam.pressure),
+            },
+            hold_state=True,
+        )
+        # Release mass flow rate
+        steam.flow_mass_phase_comp["Vap", "H2O"].unfix()
+        steam.flow_mass_phase_comp["Liq", "H2O"].unfix()
+
+        """
+        Specify motive steam state properties
+        """
+        # Calculate temperature of the motive steam (saturated)
+        med_tvc.motive_steam_props.calculate_state(
+            var_args={
+                ("pressure", None): motive_pressure * 1e5,
+                ("pressure_sat", None): motive_pressure * 1e5,
+            },
+            hold_state=True,
+        )
+        # Release mass flow rate
+        motive.flow_mass_phase_comp["Vap", "H2O"].unfix()
+        motive.flow_mass_phase_comp["Liq", "H2O"].unfix()
+
+        # Fix target recovery rate
+        med_tvc.recovery_vol_phase[0, "Liq"].fix(recovery_ratio)
+
+        # Set scaling factors for mass flow rates
+        m.fs.liquid_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
+        )
+        m.fs.liquid_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e3, index=("Liq", "TDS")
+        )
+        m.fs.vapor_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1e-2, index=("Liq", "H2O")
+        )
+        m.fs.vapor_prop.set_default_scaling(
+            "flow_mass_phase_comp", 1, index=("Vap", "H2O")
+        )
+        
+        calculate_scaling_factors(m)
+        initialization_tester(m, unit=m.fs.med_tvc, outlvl=idaeslog.DEBUG)
+        results = solver.solve(m)        
+
+
+        # Check interpolated results for different number of effects: {number_effects: result}
+        gain_output_ratios = {9: 10.299 , 11: 12.067 , 13: 13.709, 15: 15.218}
+        specific_areas = {9: 3.514 , 11: 4.682 , 13: 5.797, 15: 7.689}
+        heating_steam_mass_flow_rates = {9: 2.642 , 11: 2.834 , 13: 2.518, 15: 2.786}
+        motive_steam_mass_flow_rates = {9: 1.162 , 11: 1.334 , 13: 1.152, 15: 1.407}
+        
+        assert pytest.approx(gain_output_ratios[number_effects], rel=1e-3) == value(m.fs.med_tvc.gain_output_ratio)
+        assert pytest.approx(specific_areas[number_effects], rel=1e-3) == value(
             m.fs.med_tvc.specific_area_per_m3_day
         )
-        assert pytest.approx(66.643, rel=1e-3) == value(
-            m.fs.med_tvc.specific_energy_consumption_thermal
-        )
-        assert pytest.approx(5553.55, rel=1e-3) == value(
-            m.fs.med_tvc.thermal_power_requirement
-        )
-        assert pytest.approx(2.642, rel=1e-3) == value(
+        assert pytest.approx(heating_steam_mass_flow_rates[number_effects], rel=1e-3) == value(
             m.fs.med_tvc.heating_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
         )
-        assert pytest.approx(1.162, rel=1e-3) == value(
+        assert pytest.approx(motive_steam_mass_flow_rates[number_effects], rel=1e-3) == value(
             m.fs.med_tvc.motive_steam_props[0].flow_mass_phase_comp["Vap", "H2O"]
-        )
-        assert pytest.approx(267.76, rel=1e-3) == value(
-            pyunits.convert(
-                m.fs.med_tvc.cooling_out_props[0].flow_vol_phase["Liq"],
-                to_units=pyunits.m**3 / pyunits.hr,
-            )
         )


### PR DESCRIPTION
### Minor changes on LT-MED model to be consistent with the latest MED-TVC model from PR #32 

### Add interpolation for intermediate number of effects that doesn't have a surrogate equation
- Change parameter `number_effects` to a CONFIG block
- Expand the range of effect number in LT-MED from [3,6,9,12,14] to 3-14
- Expand the range of effect number in MED-TVC from [8,10,12,14,16] to 8-16
- Test of the interpolated results were done locally, and I don't feel the need to add a separate test for an interpolated value (so far).  