### PR TITLE
Modify LT_MED and PV_RO for Pyomo 6.6.1 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "watertap @ https://github.com/watertap-org/watertap/archive/refs/tags/pr967.zip",
-        # "pyomo <= 6.5",
+        "pyomo == 6.6.1",
         "pytest >= 7",
         "nrel-pysam == 3.0.2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "watertap @ https://github.com/watertap-org/watertap/archive/refs/tags/pr967.zip",
-        "pyomo == 6.6.1",
+        "pyomo <= 6.6.1",
         "pytest >= 7",
         "nrel-pysam == 3.0.2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "watertap @ https://github.com/watertap-org/watertap/archive/refs/tags/pr967.zip",
-        "pyomo <= 6.5",
+        # "pyomo <= 6.5",
         "pytest >= 7",
         "nrel-pysam == 3.0.2",
     ],

--- a/src/watertap_contrib/seto/analysis/net_metering/PV_RO.py
+++ b/src/watertap_contrib/seto/analysis/net_metering/PV_RO.py
@@ -17,6 +17,7 @@ from idaes.core import FlowsheetBlock
 from idaes.core.solvers.get_solver import get_solver
 from idaes.models.unit_models import Product, Feed
 from idaes.core.util.model_statistics import degrees_of_freedom
+import idaes.core.util.scaling as iscale
 from idaes.core.util.scaling import (
     set_scaling_factor,
     calculate_scaling_factors,
@@ -241,6 +242,14 @@ def initialize_treatment(m, water_recovery=0.5):
     p1.initialize()
 
     propagate_state(m.fs.treatment.a2)
+
+    ro.calculate_scaling_factors()
+    iscale.constraint_scaling_transform(ro.eq_mass_frac_permeate[0, 1, "NaCl"], 1e3)
+    iscale.constraint_scaling_transform(ro.eq_mass_frac_permeate[0, 0, "NaCl"], 1e3)
+    iscale.constraint_scaling_transform(ro.feed_side.eq_K[0, 1, "NaCl"], 1e3)
+    iscale.constraint_scaling_transform(ro.feed_side.eq_K[0, 0, "NaCl"], 1e3)
+    iscale.constraint_scaling_transform(ro.eq_flux_mass[0, 1, "Liq", "NaCl"], 1e3)
+    iscale.constraint_scaling_transform(ro.eq_flux_mass[0, 0, "Liq", "NaCl"], 1e3)
     ro.initialize()
     ro.area.unfix()
     ro.recovery_mass_phase_comp[0, "Liq", "H2O"].fix(water_recovery)

--- a/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/seto/unit_models/surrogate/lt_med_surrogate.py
@@ -746,7 +746,7 @@ class LTMEDData(UnitModelBlockData):
             * iscale.get_scaling_factor(
                 self.cooling_out_props[0].enth_mass_phase["Liq"]
             )
-            * 1e-3
+            * 0.25
         )
         iscale.constraint_scaling_transform(self.eq_feed_cool_mass_flow, sf)
 


### PR DESCRIPTION
#### Updated the scaling factors so that the following models are compatible with both Pyomo 6.5.0 and 6.6.1:
- Modified the scaling factor of 1 constraint in LT_MED
- Added the scaling factors for 3 constraints in reverse_osmosis_0D model that is used in PV_RO